### PR TITLE
Replace conda with pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ custom.cfg
 *.sqlite
 *.bak
 __pycache__
+venv/
 
 # Unit test / Coverage reports
 .cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.6
 
 MAINTAINER https://github.com/pacificclimate/thunderbird
 LABEL Description="thunderbird WPS" Vendor="Birdhouse" Version="0.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,30 @@
-# vim:set ft=dockerfile:
-FROM continuumio/miniconda3
+FROM python:3.7
+
 MAINTAINER https://github.com/pacificclimate/thunderbird
 LABEL Description="thunderbird WPS" Vendor="Birdhouse" Version="0.1.0"
 
 # Update Debian system
 RUN apt-get update && apt-get install -y \
- build-essential \
-&& rm -rf /var/lib/apt/lists/*
+    build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
-# Update conda
-RUN conda update -n base conda
+# Upgrade pip
+RUN pip install --upgrade pip
 
 # Copy WPS project
 COPY . /opt/wps
-
 WORKDIR /opt/wps
 
-# Create conda environment
-RUN conda env create -n wps -f environment.yml
+# Create python environment
+RUN python3 -m venv venv
 
 # Install WPS
-RUN ["/bin/bash", "-c", "source activate wps && python setup.py develop"]
+RUN ["/bin/bash", "-c", "source venv/bin/activate && pip install -i https://pypi.pacificclimate.org/simple/ -r requirements.txt && pip install -e ."]
 
 # Start WPS service on port 5001 on 0.0.0.0
 EXPOSE 5001
 ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["source activate wps && exec thunderbird start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"]
+CMD ["source venv/bin/activate && exec thunderbird start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"]
 
 # docker build -t pacificclimate/thunderbird .
 # docker run -p 5001:5001 pacificclimate/thunderbird

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM continuumio/miniconda3
-MAINTAINER https://github.com/nikola-rados/thunderbird
+MAINTAINER https://github.com/pacificclimate/thunderbird
 LABEL Description="thunderbird WPS" Vendor="Birdhouse" Version="0.1.0"
 
 # Update Debian system
@@ -27,7 +27,7 @@ EXPOSE 5001
 ENTRYPOINT ["/bin/bash", "-c"]
 CMD ["source activate wps && exec thunderbird start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"]
 
-# docker build -t nikola-rados/thunderbird .
-# docker run -p 5001:5001 nikola-rados/thunderbird
+# docker build -t pacificclimate/thunderbird .
+# docker run -p 5001:5001 pacificclimate/thunderbird
 # http://localhost:5001/wps?request=GetCapabilities&service=WPS
 # http://localhost:5001/wps?request=DescribeProcess&service=WPS&identifier=all&version=1.0.0

--- a/README.rst
+++ b/README.rst
@@ -5,12 +5,12 @@ thunderbird
    :target: http://thunderbird.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-.. image:: https://travis-ci.org/nikola-rados/thunderbird.svg?branch=master
-   :target: https://travis-ci.org/nikola-rados/thunderbird
+.. image:: https://travis-ci.org/pacificclimate/thunderbird.svg?branch=master
+   :target: https://travis-ci.org/pacificclimate/thunderbird
    :alt: Travis Build
 
-.. image:: https://img.shields.io/github/license/nikola-rados/thunderbird.svg
-    :target: https://github.com/nikola-rados/thunderbird/blob/master/LICENSE.txt
+.. image:: https://img.shields.io/github/license/pacificclimate/thunderbird.svg
+    :target: https://github.com/pacificclimate/thunderbird/blob/master/LICENSE.txt
     :alt: GitHub license
 
 .. image:: https://badges.gitter.im/bird-house/birdhouse.svg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   wps:
     build: .
-    image: nikola-rados/thunderbird
+    image: pacificclimate/thunderbird
     ports:
       - "5001:5001"
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,7 +21,7 @@ Check out code from the thunderbird GitHub repo and start the installation:
 
 .. code-block:: console
 
-   $ git clone https://github.com/nikola-rados/thunderbird.git
+   $ git clone https://github.com/pacificclimate/thunderbird.git
    $ cd thunderbird
 
 Create Conda environment named `thunderbird`:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description=README + "\n\n" + CHANGES,
     author=about["__author__"],
     author_email=about["__email__"],
-    url="https://github.com/nikola-rados/thunderbird",
+    url="https://github.com/pacificclimate/thunderbird",
     classifiers=classifiers,
     license="GNU General Public License v3",
     keywords="wps pywps birdhouse thunderbird",


### PR DESCRIPTION
Out of the box the `cookiecutter bird` creates a `Dockerfile` that uses `conda`. It has been updated to use `pip` instead.  Issue #4 called to remove any `conda` items, but I feel we should keep them around just in case.  Please note there were a small number of documentation changes to address a mistake.

Resolves #4 