### PR TITLE
Add pavics component config

### DIFF
--- a/pavics-component/.gitignore
+++ b/pavics-component/.gitignore
@@ -1,3 +1,4 @@
 wps.cfg
 thunderbird-magpie-permission.cfg
 thunderbird-magpie-provider.cfg
+thunderbird_canarie_api_monitoring.py

--- a/pavics-component/.gitignore
+++ b/pavics-component/.gitignore
@@ -1,0 +1,3 @@
+wps.cfg
+thunderbird-magpie-permission.cfg
+thunderbird-magpie-provider.cfg

--- a/pavics-component/docker-compose-extra.yml
+++ b/pavics-component/docker-compose-extra.yml
@@ -17,3 +17,7 @@ services:
     volumes:
     - ../../thunderbird/pavics-component/thunderbird-magpie-permission.cfg:/opt/local/src/magpie/config/permissions/thunderbird-magpie-permission.cfg:ro
     - ../../thunderbird/pavics-component/thunderbird-magpie-provider.cfg:/opt/local/src/magpie/config/providers/thunderbird-magpie-provider.cfg:ro
+
+  proxy:
+    volumes:
+      - ../../thunderbird/pavics-component/thunderbird_canarie_api_monitoring.py:${CANARIE_MONITORING_EXTRA_CONF_DIR}/thunderbird_canarie_api_monitoring.py:ro

--- a/pavics-component/docker-compose-extra.yml
+++ b/pavics-component/docker-compose-extra.yml
@@ -1,0 +1,19 @@
+version: '2.1'
+services:
+  thunderbird:
+    image: ${THUNDERBIRD_IMAGE}
+    container_name: thunderbird
+    environment:
+      - PYWPS_CFG=/wps.cfg
+    ports:
+      - "8099:5001"
+    volumes:
+      - ../../thunderbird/pavics-component/wps.cfg:/wps.cfg
+      - wps_outputs:/data/wpsoutputs
+      - /tmp
+    restart: always
+
+  magpie:
+    volumes:
+    - ../../thunderbird/pavics-component/thunderbird-magpie-permission.cfg:/opt/local/src/magpie/config/permissions/thunderbird-magpie-permission.cfg:ro
+    - ../../thunderbird/pavics-component/thunderbird-magpie-provider.cfg:/opt/local/src/magpie/config/providers/thunderbird-magpie-provider.cfg:ro

--- a/pavics-component/thunderbird-magpie-permission.cfg.template
+++ b/pavics-component/thunderbird-magpie-permission.cfg.template
@@ -1,0 +1,15 @@
+permissions:
+  - service: thunderbird
+    permission: getcapabilities
+    group: anonymous
+    action: create
+
+  - service: thunderbird
+    permission: describeprocess
+    group: anonymous
+    action: create
+
+  - service: thunderbird
+    permission: execute
+    group: anonymous
+    action: create

--- a/pavics-component/thunderbird-magpie-provider.cfg.template
+++ b/pavics-component/thunderbird-magpie-provider.cfg.template
@@ -1,0 +1,8 @@
+providers:
+  thunderbird:
+    url: http://${PAVICS_FQDN}:8099/wps
+    title: Thunderbird
+    public: true
+    c4i: false
+    type: wps
+    sync_type: wps

--- a/pavics-component/thunderbird_canarie_api_monitoring.py.template
+++ b/pavics-component/thunderbird_canarie_api_monitoring.py.template
@@ -1,0 +1,14 @@
+SERVICES['node']['monitoring'].update({
+    'Thunderbird-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/thunderbird?service=WPS&version=1.0.0&request=GetCapabilities'
+        },
+    },
+    'Thunderbird': {
+        'request': {
+            'url': 'http://${PAVICS_FQDN}:8099/wps?service=WPS&version=1.0.0&request=GetCapabilities'
+        }
+    },
+})
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4 syntax=python

--- a/pavics-component/wps.cfg.template
+++ b/pavics-component/wps.cfg.template
@@ -1,0 +1,8 @@
+[server]
+outputurl = https://${PAVICS_FQDN_PUBLIC}/wpsoutputs
+outputpath = /data/wpsoutputs
+
+[logging]
+level = DEBUG
+
+${EXTRA_PYWPS_CONFIG}


### PR DESCRIPTION
@nikola-rados This requires the PR https://github.com/bird-house/birdhouse-deploy/pull/36 on `birdhouse-deploy` repo.

@huard, @tlogan2000, FYI how a component can be hooked into our PAVICS stack without any code change. 

Assume `thunderbird` repo is checkout along-side with `birdhouse-deploy`
repo because we use `../../thunderbird/pavics-component` path for volume
mount.

`env.local` config to add to activate this component:
```
  export EXTRA_CONF_DIRS="$EXTRA_CONF_DIRS /somepath/thunderbird/pavics-component"
  export AUTODEPLOY_EXTRA_REPOS="$AUTODEPLOY_EXTRA_REPOS /somepath/thunderbird/pavics-component"
  export THUNDERBIRD_IMAGE="tlvu/thunderbird:i3-gen-climos"
```

The bird will be accessible at
https://$PAVICS_FQDN/twitcher/ows/proxy/thunderbird/wps or
http://$PAVICS_FQDN:8099/wps.

Public port 8099, same as the existing `docker-compose.yml`.

Magpie permissions give full public access to the bird.  This should be
adjusted later.  Or this file can simply be replaced for a different
permission level.

Canarie api monitoring enable for both the public (behind httpS and Twitcher) and internal (direct
http access) link of thunderbird.

I very superficially tried with a notebook here https://gist.github.com/tlvu/4d892af22bc34ae39443171ad8317439 on PAVICS's Jupyter env: https://lvupavics-lvu.pagekite.me/jupyter/hub/user-redirect/lab/tree/writable-workspace/thunderbird.ipynb (user `demo`)

![Screenshot_2020-03-30 thunderbird ipynb](https://user-images.githubusercontent.com/11966697/77979068-a4647600-72d1-11ea-8053-69719d378c2a.png)

Canarie Monitoring page https://lvupavics-lvu.pagekite.me/canarie/node/service/status :
![Screenshot_2020-03-30 Ouranos - Node Service](https://user-images.githubusercontent.com/11966697/77979155-dece1300-72d1-11ea-850e-ba953f59c8e8.png)
