### PR TITLE
Replace opendap variable with netcdf

### DIFF
--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,15 +30,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f22359e4588>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/github/pcic/thunderbird/notebooks/demo_venv/lib/python3.6/site-packages/birdy/client/base.py\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7fc7d8482470>\n",
+       "\u001b[0;31mFile:\u001b[0m            ~/thunderbird-venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Explorer data preparation\n",
        "\n",
@@ -49,7 +49,10 @@
        "    Generate files containing climatological means from input files of daily, monthly, or yearly data that adhere to the PCIC metadata standard (and consequently to CMIP5 and CF standards).\n",
        "\n",
        "generate_prsn\n",
-       "    Generate Precipitation as Snow\n",
+       "    Generate precipitation as snow file from precipitation and minimum/maximum temperature data\n",
+       "\n",
+       "update_metadata\n",
+       "    Update file containing missing, invalid, or incorrectly named global or variable metadata attributes\n",
        "\n",
        "hello\n",
        "    Just says a friendly Hello.Returns a literal string output with Hello plus the inputed name.\n",
@@ -91,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -99,30 +102,27 @@
       "text/plain": [
        "\u001b[0;31mSignature:\u001b[0m\n",
        "\u001b[0mthunderbird\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgenerate_climos\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mnetcdf\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0moperation\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mclimo\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mresolutions\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mdry_run\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mdry_run\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mconvert_longitudes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0msplit_vars\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0msplit_intervals\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mopendap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mnetcdf\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Generate files containing climatological means from input files of daily, monthly, or yearly data that adhere to the PCIC metadata standard (and consequently to CMIP5 and CF standards).\n",
        "\n",
        "Parameters\n",
        "----------\n",
-       "opendap : ComplexData:mimetype:`application/x-ogc-dods`\n",
-       "    Path to OPEnDAP resource\n",
-       "netcdf : ComplexData:mimetype:`application/x-netcdf`\n",
+       "netcdf : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`application/x-ogc-dods`\n",
        "    NetCDF file\n",
        "operation : {'mean', 'std'}string\n",
        "    Operation to perform on the datasets\n",
        "climo : {'all', 'historical', 'futures', '6190', '7100', '8100', '2020', '2050', '2080'}string\n",
        "    Year ranges\n",
-       "resolutions : {'all', 'yearly', 'seasonal', 'monthy'}string\n",
+       "resolutions : {'all', 'yearly', 'seasonal', 'monthly'}string\n",
        "    Temporal Resolutions\n",
        "convert_longitudes : boolean\n",
        "    Transform longitude range from [0, 360) to [-180, 180)\n",
@@ -139,7 +139,7 @@
        "    Collection of climatoligical files\n",
        "dry_output : ComplexData:mimetype:`text/plain`\n",
        "    File information\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/github/pcic/thunderbird/notebooks/</home/nrados/github/pcic/thunderbird/notebooks/demo_venv/lib/python3.6/site-packages/birdy/client/base.py-2>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/thunderbird/notebooks/</home/slim/thunderbird-venv/lib/python3.6/site-packages/birdy/client/base.py-0>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -154,19 +154,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Dry run process\n",
-    "opendap = 'http://docker-dev03.pcic.uvic.ca:8083/twitcher/ows/proxy/thredds/dodsC/datasets/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc'\n",
+    "netcdf = 'http://docker-dev03.pcic.uvic.ca:8083/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc'\n",
     "operation = 'mean'\n",
     "climo = '6190'\n",
     "resolutions = 'yearly'\n",
     "dry_run = True\n",
     "\n",
     "dry_output = thunderbird.generate_climos(\n",
-    "    opendap=opendap, \n",
+    "    netcdf=netcdf, \n",
     "    operation=operation, \n",
     "    climo=climo, \n",
     "    resolutions=resolutions, \n",
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -184,7 +184,7 @@
      "output_type": "stream",
      "text": [
       "Dry Run\n",
-      "File: http://docker-dev03.pcic.uvic.ca:8083/twitcher/ows/proxy/thredds/dodsC/datasets/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc\n",
+      "File: http://docker-dev03.pcic.uvic.ca:8083/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc\n",
       "climo_periods: {'6190'}\n",
       "project: CMIP5\n",
       "institution: PCIC\n",
@@ -206,13 +206,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "# generate climos\n",
     "output = thunderbird.generate_climos(\n",
-    "    opendap=opendap, \n",
+    "    netcdf=netcdf, \n",
     "    operation=operation, \n",
     "    climo=climo, \n",
     "    resolutions=resolutions, \n",
@@ -222,16 +222,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<metaurl mediatype=\"application/x-netcdf\">http://localhost:5001/outputs/af5a5dca-a52d-11ea-a26e-dc71961151bb/fdd_aClimMean_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231_Canada.nc</metaurl>"
+       "<metaurl mediatype=\"application/x-netcdf\">http://localhost:5001/outputs/e0ccf040-af4e-11ea-afd0-c86000e3f2fd/fdd_aClimMean_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231_Canada.nc</metaurl>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/demo_update_metadata.ipynb
+++ b/notebooks/demo_update_metadata.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,15 +24,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/slim/Desktop/thunderbird/tests\n",
-      "file:////home/slim/Desktop/thunderbird/tests/metadata-conversion/simple-conversion.yaml\n"
+      "/home/slim/thunderbird/tests\n",
+      "file:////home/slim/thunderbird/tests/metadata-conversion/simple-conversion.yaml\n"
      ]
     }
    ],
@@ -41,12 +41,12 @@
     "print(os.getcwd())\n",
     "updates = \"file:///{}\".format(os.path.join(os.getcwd(), \"metadata-conversion/simple-conversion.yaml\"))\n",
     "print(updates)\n",
-    "opendap = \"http://docker-dev03.pcic.uvic.ca:8083/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\""
+    "netcdf = \"http://docker-dev03.pcic.uvic.ca:8083/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -58,12 +58,12 @@
     }
    ],
    "source": [
-    "output = thunderbird.update_metadata(updates = updates, opendap = opendap)"
+    "output = thunderbird.update_metadata(updates = updates, netcdf = netcdf)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -73,8 +73,8 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mProcessFailed\u001b[0m                             Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-17-0bd7cb63806f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Desktop/thunderbird/venv1/lib/python3.7/site-packages/birdy/client/outputs.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, asobj)\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misSucceded\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     30\u001b[0m             \u001b[0;31m# TODO: add reason for failure\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 31\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mProcessFailed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Sorry, process failed.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     32\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_output\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0masobj\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-5-0bd7cb63806f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/thunderbird-venv/lib/python3.6/site-packages/birdy/client/outputs.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, asobj)\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misSucceded\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     30\u001b[0m             \u001b[0;31m# TODO: add reason for failure\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 31\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mProcessFailed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Sorry, process failed.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     32\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_output\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0masobj\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mProcessFailed\u001b[0m: Sorry, process failed."
      ]
     }
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,28 +97,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "output = thunderbird.update_metadata(updates = updates, opendap = opendap)"
+    "output = thunderbird.update_metadata(updates = updates, netcdf = netcdf)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "update_metadataResponse(\n",
-      "    output='http://localhost:5001/outputs/c575c29e-a784-11ea-9d28-503eaa25cee0/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100_copy.nc'\n",
-      ")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(output.get())"
    ]
@@ -147,7 +137,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/demo_update_metadata.ipynb
+++ b/notebooks/demo_update_metadata.ipynb
@@ -32,14 +32,14 @@
      "output_type": "stream",
      "text": [
       "/home/slim/thunderbird/tests\n",
-      "file:////home/slim/thunderbird/tests/metadata-conversion/simple-conversion.yaml\n"
+      "/home/slim/thunderbird/tests/metadata-conversion/simple-conversion.yaml\n"
      ]
     }
    ],
    "source": [
     "os.chdir('../tests')\n",
     "print(os.getcwd())\n",
-    "updates = \"file:///{}\".format(os.path.join(os.getcwd(), \"metadata-conversion/simple-conversion.yaml\"))\n",
+    "updates = os.path.join(os.getcwd(), \"metadata-conversion/simple-conversion.yaml\")\n",
     "print(updates)\n",
     "netcdf = \"http://docker-dev03.pcic.uvic.ca:8083/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\""
    ]
@@ -48,15 +48,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process failed, please check server error log'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "output = thunderbird.update_metadata(updates = updates, netcdf = netcdf)"
    ]
@@ -67,15 +59,12 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "ProcessFailed",
-     "evalue": "Sorry, process failed.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mProcessFailed\u001b[0m                             Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-5-0bd7cb63806f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/thunderbird-venv/lib/python3.6/site-packages/birdy/client/outputs.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, asobj)\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misSucceded\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     30\u001b[0m             \u001b[0;31m# TODO: add reason for failure\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 31\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mProcessFailed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Sorry, process failed.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     32\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_output\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0masobj\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mProcessFailed\u001b[0m: Sorry, process failed."
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "update_metadataResponse(\n",
+      "    output='http://localhost:5001/outputs/a3d923c2-af51-11ea-afd0-c86000e3f2fd/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100_copy.nc'\n",
+      ")\n"
      ]
     }
    ],
@@ -85,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,9 +95,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "update_metadataResponse(\n",
+      "    output='http://localhost:5001/outputs/a669a346-af51-11ea-afd0-c86000e3f2fd/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100_copy.nc'\n",
+      ")\n"
+     ]
+    }
+   ],
    "source": [
     "print(output.get())"
    ]


### PR DESCRIPTION
This PR replaces the uses of `opendap` in the `demo.ipynb` and `demo_update_metadata.ipynb` notebooks with `netcdf` to be up to date with the refactoring.