### PR TITLE
Fix errors in wps_generate_climos online tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -25,7 +25,7 @@ global:
 
 TESTDATA = {
     "test_local_nc": test_files,
-    "test_opendap": "http://test.opendap.org:80/opendap/netcdf/examples/sresa1b_ncar_ccsm3_0_run1_200001.nc",
+    "test_opendap": "http://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc",
     "test_local_pr_nc": "file:///{}".format(
         resource_filename("tests", "data/pr_week_test.nc")
     ),

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -15,10 +15,10 @@ from thunderbird.processes.wps_generate_climos import GenerateClimos
     ("kwargs"),
     [
         (
-            {
+           {
                 "operation": "mean",
                 "climo": "6190",
-                "resolutions": "yearly",
+                "resolutions": "all",
                 "convert_longitudes": "True",
                 "split_vars": "True",
                 "split_intervals": "True",

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -15,7 +15,7 @@ from thunderbird.processes.wps_generate_climos import GenerateClimos
     ("kwargs"),
     [
         (
-           {
+            {
                 "operation": "mean",
                 "climo": "6190",
                 "resolutions": "all",


### PR DESCRIPTION
The opendap file in `common.py` has been changed to 
`http://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc` and the resolution in the online test where `dry_run = False` has been changed to `"all"` to fix the errors/warnings with these tests.