### PR TITLE
Issue/37 wps_generate_climos modified to adapt the version change in ce-dataprep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pywps>=4.2.0<4.3
 jinja2
 click
 psutil
-ce-dataprep==0.8.1
+ce-dataprep==0.8.2
 cftime==1.1.3
 xarray==0.15.1

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,6 +10,7 @@ xpath_ns = get_xpath_ns(VERSION)
 test_files = [
     "file:///{}".format(pkg_resources.resource_filename(__name__, "data/" + test_file))
     for test_file in pkg_resources.resource_listdir(__name__, "data")
+    if test_file.startswith("tiny_")
 ]
 
 yaml_files = [

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -69,7 +69,6 @@ local_test_data = [
     nc for nc in TESTDATA["test_local_nc"] if not nc.endswith("_climos.nc")
 ]
 
-
 @pytest.mark.parametrize(
     ("netcdf"), local_test_data,
 )
@@ -98,47 +97,21 @@ local_test_data = [
                 "dry_run": "True",
             }
         ),
+        # missing arguments
+        (
+            {
+                "operation": "mean",
+                "climo": None,
+                "resolutions": None,
+                "convert_longitudes": None,
+                "split_vars": None,
+                "split_intervals": None,
+                "dry_run": "True",
+            }
+        ),
     ],
 )
 def test_wps_gen_climos_local_nc(netcdf, kwargs):
     run_wps_generate_climos(netcdf, kwargs)
 
 
-@pytest.mark.parametrize(
-    ("resolutions", "expected"),
-    [
-        (["all"], ["yearly", "seasonal", "monthly"]),
-        (["all", "yearly"], ["yearly", "seasonal", "monthly"]),
-        (["yearly"], ["yearly"]),
-        (["monthly", "seasonal"], ["seasonal", "monthly"]),
-    ],
-)
-def test_format_resolutions(resolutions, expected):
-    gc = GenerateClimos()
-    output = gc.format_resolutions(resolutions)
-    assert len(output) == len(expected)
-    for resolution in output:
-        assert resolution in expected
-
-
-@pytest.mark.parametrize(
-    ("climo", "expected"),
-    [
-        (["all"], ["6190", "7100", "8100", "2020", "2050", "2080"]),
-        (["all", "historical"], ["6190", "7100", "8100", "2020", "2050", "2080"],),
-        (["all", "futures"], ["6190", "7100", "8100", "2020", "2050", "2080"],),
-        (["futures"], ["2020", "2050", "2080"]),
-        (["futures", "6190"], ["2020", "2050", "2080", "6190"]),
-        (["historical", "2050"], ["6190", "7100", "8100", "2050"]),
-        (
-            ["historical", "futures", "6190", "2080"],
-            ["6190", "7100", "8100", "2020", "2050", "2080"],
-        ),
-    ],
-)
-def test_format_climo(climo, expected):
-    gc = GenerateClimos()
-    output = gc.format_climo(climo)
-    assert len(output) == len(expected)
-    for climo in output:
-        assert climo in expected

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -116,7 +116,6 @@ def test_wps_gen_climos_local_nc(netcdf, kwargs):
 def test_format_resolutions(resolutions, expected):
     gc = GenerateClimos()
     output = gc.format_resolutions(resolutions)
-    print(output)
     assert len(output) == len(expected)
     for resolution in output:
         assert resolution in expected

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -60,6 +60,58 @@ def test_wps_gen_climos_opendap(netcdf, kwargs):
     )
     assert_response_success(resp)
 
+@pytest.mark.parametrize(
+    ("netcdf"), (TESTDATA["test_local_nc"]),
+)
+@pytest.mark.parametrize(
+    ("kwargs"),
+    [
+        (
+            {
+                "operation": "mean",
+                "climo": "6190",
+                "resolutions": "all",
+                "convert_longitudes": "True",
+                "split_vars": "True",
+                "split_intervals": "True",
+                "dry_run": "False",
+            }
+        ),
+        (
+            {
+                "operation": "std",
+                "climo": "7100",
+                "resolutions": "monthly",
+                "convert_longitudes": "False",
+                "split_vars": "False",
+                "split_intervals": "False",
+                "dry_run": "True",
+            }
+        ),
+    ],
+)
+def test_wps_gen_climos_local_nc(netcdf, kwargs):
+    print(netcdf)
+    client = client_for(Service(processes=[GenerateClimos()]))
+    datainputs = (
+        "netcdf=@xlink:href={0};"
+        "operation={operation};"
+        "climo={climo};"
+        "resolutions={resolutions};"
+        "convert_longitudes={convert_longitudes};"
+        "split_vars={split_vars};"
+        "split_intervals={split_intervals};"
+        "dry_run={dry_run};"
+    ).format(netcdf, **kwargs)
+
+    resp = client.get(
+        service="wps",
+        request="Execute",
+        version="1.0.0",
+        identifier="generate_climos",
+        datainputs=datainputs,
+    )
+    assert_response_success(resp)
 
 @pytest.mark.parametrize(
     ("resolutions", "expected"),
@@ -73,6 +125,7 @@ def test_wps_gen_climos_opendap(netcdf, kwargs):
 def test_format_resolutions(resolutions, expected):
     gc = GenerateClimos()
     output = gc.format_resolutions(resolutions)
+    print(output)
     assert len(output) == len(expected)
     for resolution in output:
         assert resolution in expected

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -10,7 +10,6 @@ from thunderbird.processes.wps_generate_climos import GenerateClimos
 def run_wps_generate_climos(netcdf, datainputs):
     client = client_for(Service(processes=[GenerateClimos()]))
 
-
     resp = client.get(
         service="wps",
         request="Execute",
@@ -117,26 +116,17 @@ def test_wps_gen_climos_local_nc(netcdf, kwargs):
 
     run_wps_generate_climos(netcdf, datainputs)
 
+
 @pytest.mark.parametrize(
     ("netcdf"), local_test_data,
 )
 @pytest.mark.parametrize(
-    ("kwargs"),
-    [
-        (
-            {
-                "operation": "mean",
-                "dry_run": "False",
-            }
-        ),
-    ],
+    ("kwargs"), [({"operation": "mean", "dry_run": "False",}),],
 )
 def test_missing_arguments(netcdf, kwargs):
     client = client_for(Service(processes=[GenerateClimos()]))
     datainputs = (
-        "netcdf=@xlink:href={0};"
-        "operation={operation};"
-        "dry_run={dry_run};"
+        "netcdf=@xlink:href={0};" "operation={operation};" "dry_run={dry_run};"
     ).format(netcdf, **kwargs)
 
     run_wps_generate_climos(netcdf, datainputs)

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -7,18 +7,9 @@ from .common import client_for, TESTDATA
 from thunderbird.processes.wps_generate_climos import GenerateClimos
 
 
-def run_wps_generate_climos(netcdf, kwargs):
+def run_wps_generate_climos(netcdf, datainputs):
     client = client_for(Service(processes=[GenerateClimos()]))
-    datainputs = (
-        "netcdf=@xlink:href={0};"
-        "operation={operation};"
-        "climo={climo};"
-        "resolutions={resolutions};"
-        "convert_longitudes={convert_longitudes};"
-        "split_vars={split_vars};"
-        "split_intervals={split_intervals};"
-        "dry_run={dry_run};"
-    ).format(netcdf, **kwargs)
+
 
     resp = client.get(
         service="wps",
@@ -62,7 +53,18 @@ def run_wps_generate_climos(netcdf, kwargs):
     ],
 )
 def test_wps_gen_climos_opendap(netcdf, kwargs):
-    run_wps_generate_climos(netcdf, kwargs)
+    datainputs = (
+        "netcdf=@xlink:href={0};"
+        "operation={operation};"
+        "climo={climo};"
+        "resolutions={resolutions};"
+        "convert_longitudes={convert_longitudes};"
+        "split_vars={split_vars};"
+        "split_intervals={split_intervals};"
+        "dry_run={dry_run};"
+    ).format(netcdf, **kwargs)
+
+    run_wps_generate_climos(netcdf, datainputs)
 
 
 # running generate_climos on climo files is againt the purpose of the program
@@ -99,19 +101,42 @@ local_test_data = [
                 "dry_run": "True",
             }
         ),
-        # missing arguments
+    ],
+)
+def test_wps_gen_climos_local_nc(netcdf, kwargs):
+    datainputs = (
+        "netcdf=@xlink:href={0};"
+        "operation={operation};"
+        "climo={climo};"
+        "resolutions={resolutions};"
+        "convert_longitudes={convert_longitudes};"
+        "split_vars={split_vars};"
+        "split_intervals={split_intervals};"
+        "dry_run={dry_run};"
+    ).format(netcdf, **kwargs)
+
+    run_wps_generate_climos(netcdf, datainputs)
+
+@pytest.mark.parametrize(
+    ("netcdf"), local_test_data,
+)
+@pytest.mark.parametrize(
+    ("kwargs"),
+    [
         (
             {
                 "operation": "mean",
-                "climo": None,
-                "resolutions": None,
-                "convert_longitudes": None,
-                "split_vars": None,
-                "split_intervals": None,
-                "dry_run": "True",
+                "dry_run": "False",
             }
         ),
     ],
 )
-def test_wps_gen_climos_local_nc(netcdf, kwargs):
-    run_wps_generate_climos(netcdf, kwargs)
+def test_missing_arguments(netcdf, kwargs):
+    client = client_for(Service(processes=[GenerateClimos()]))
+    datainputs = (
+        "netcdf=@xlink:href={0};"
+        "operation={operation};"
+        "dry_run={dry_run};"
+    ).format(netcdf, **kwargs)
+
+    run_wps_generate_climos(netcdf, datainputs)

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -64,7 +64,7 @@ def run_wps_generate_climos(netcdf, kwargs):
 def test_wps_gen_climos_opendap(netcdf, kwargs):
     run_wps_generate_climos(netcdf, kwargs)
 
-
+# running generate_climos on climo files is againt the purpose of the program
 local_test_data = [
     nc for nc in TESTDATA["test_local_nc"] if not nc.endswith("_climos.nc")
 ]

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -64,10 +64,12 @@ def run_wps_generate_climos(netcdf, kwargs):
 def test_wps_gen_climos_opendap(netcdf, kwargs):
     run_wps_generate_climos(netcdf, kwargs)
 
+
 # running generate_climos on climo files is againt the purpose of the program
 local_test_data = [
     nc for nc in TESTDATA["test_local_nc"] if not nc.endswith("_climos.nc")
 ]
+
 
 @pytest.mark.parametrize(
     ("netcdf"), local_test_data,
@@ -113,5 +115,3 @@ local_test_data = [
 )
 def test_wps_gen_climos_local_nc(netcdf, kwargs):
     run_wps_generate_climos(netcdf, kwargs)
-
-

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -6,6 +6,7 @@ from pywps.tests import assert_response_success
 from .common import client_for, TESTDATA
 from thunderbird.processes.wps_generate_climos import GenerateClimos
 
+
 def run_wps_generate_climos(netcdf, kwargs):
     client = client_for(Service(processes=[GenerateClimos()]))
     datainputs = (
@@ -27,6 +28,7 @@ def run_wps_generate_climos(netcdf, kwargs):
         datainputs=datainputs,
     )
     assert_response_success(resp)
+
 
 @pytest.mark.online
 @pytest.mark.parametrize(
@@ -62,7 +64,12 @@ def run_wps_generate_climos(netcdf, kwargs):
 def test_wps_gen_climos_opendap(netcdf, kwargs):
     run_wps_generate_climos(netcdf, kwargs)
 
-local_test_data = [nc for nc in TESTDATA["test_local_nc"] if not nc.endswith("_climos.nc")]
+
+local_test_data = [
+    nc for nc in TESTDATA["test_local_nc"] if not nc.endswith("_climos.nc")
+]
+
+
 @pytest.mark.parametrize(
     ("netcdf"), local_test_data,
 )
@@ -95,6 +102,7 @@ local_test_data = [nc for nc in TESTDATA["test_local_nc"] if not nc.endswith("_c
 )
 def test_wps_gen_climos_local_nc(netcdf, kwargs):
     run_wps_generate_climos(netcdf, kwargs)
+
 
 @pytest.mark.parametrize(
     ("resolutions", "expected"),

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -6,6 +6,27 @@ from pywps.tests import assert_response_success
 from .common import client_for, TESTDATA
 from thunderbird.processes.wps_generate_climos import GenerateClimos
 
+def run_wps_generate_climos(netcdf, kwargs):
+    client = client_for(Service(processes=[GenerateClimos()]))
+    datainputs = (
+        "netcdf=@xlink:href={0};"
+        "operation={operation};"
+        "climo={climo};"
+        "resolutions={resolutions};"
+        "convert_longitudes={convert_longitudes};"
+        "split_vars={split_vars};"
+        "split_intervals={split_intervals};"
+        "dry_run={dry_run};"
+    ).format(netcdf, **kwargs)
+
+    resp = client.get(
+        service="wps",
+        request="Execute",
+        version="1.0.0",
+        identifier="generate_climos",
+        datainputs=datainputs,
+    )
+    assert_response_success(resp)
 
 @pytest.mark.online
 @pytest.mark.parametrize(
@@ -39,29 +60,11 @@ from thunderbird.processes.wps_generate_climos import GenerateClimos
     ],
 )
 def test_wps_gen_climos_opendap(netcdf, kwargs):
-    client = client_for(Service(processes=[GenerateClimos()]))
-    datainputs = (
-        "netcdf=@xlink:href={0};"
-        "operation={operation};"
-        "climo={climo};"
-        "resolutions={resolutions};"
-        "convert_longitudes={convert_longitudes};"
-        "split_vars={split_vars};"
-        "split_intervals={split_intervals};"
-        "dry_run={dry_run};"
-    ).format(netcdf, **kwargs)
+    run_wps_generate_climos(netcdf, kwargs)
 
-    resp = client.get(
-        service="wps",
-        request="Execute",
-        version="1.0.0",
-        identifier="generate_climos",
-        datainputs=datainputs,
-    )
-    assert_response_success(resp)
-
+local_test_data = [nc for nc in TESTDATA["test_local_nc"] if not nc.endswith("_climos.nc")]
 @pytest.mark.parametrize(
-    ("netcdf"), (TESTDATA["test_local_nc"]),
+    ("netcdf"), local_test_data,
 )
 @pytest.mark.parametrize(
     ("kwargs"),
@@ -91,27 +94,7 @@ def test_wps_gen_climos_opendap(netcdf, kwargs):
     ],
 )
 def test_wps_gen_climos_local_nc(netcdf, kwargs):
-    print(netcdf)
-    client = client_for(Service(processes=[GenerateClimos()]))
-    datainputs = (
-        "netcdf=@xlink:href={0};"
-        "operation={operation};"
-        "climo={climo};"
-        "resolutions={resolutions};"
-        "convert_longitudes={convert_longitudes};"
-        "split_vars={split_vars};"
-        "split_intervals={split_intervals};"
-        "dry_run={dry_run};"
-    ).format(netcdf, **kwargs)
-
-    resp = client.get(
-        service="wps",
-        request="Execute",
-        version="1.0.0",
-        identifier="generate_climos",
-        datainputs=datainputs,
-    )
-    assert_response_success(resp)
+    run_wps_generate_climos(netcdf, kwargs)
 
 @pytest.mark.parametrize(
     ("resolutions", "expected"),

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -58,7 +58,7 @@ class GenerateClimos(Process):
                 abstract="Year ranges",
                 min_occurs=0,
                 mode=0,
-                allowed_values= self.climos,
+                allowed_values=self.climos,
                 data_type="string",
             ),
             LiteralInput(
@@ -168,7 +168,7 @@ class GenerateClimos(Process):
     def format_climo(self, request, climo):
         if "climo" not in request.inputs:
             return self.climos
-        
+
         return list(
             {
                 item
@@ -190,7 +190,9 @@ class GenerateClimos(Process):
             climo = self.climos
 
         if "resolutions" in request.input:
-            resolutions = list(set([resolution.data for resolution in request.inputs["resolutions"]]))
+            resolutions = list(
+                set([resolution.data for resolution in request.inputs["resolutions"]])
+            )
         else:
             resolutions = self.resolutions
 

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -165,24 +165,6 @@ class GenerateClimos(Process):
         suffix = {"mean": "Mean", "std": "SD"}[operation]
         return "Clim" + suffix
 
-    def format_climo(self, request, climo):
-        if "climo" not in request.inputs:
-            return self.climos
-
-        return list(
-            {
-                item
-                for c in climo
-                for item in (self.climos[c] if c in self.climos.keys() else [c])
-            }
-        )
-
-    def format_resolutions(self, request, resolutions):
-        if "resolutions" not in request.inputs:
-            return self.resolutions
-
-        return list(set(resolutions))
-
     def collect_args(self, request):
         if "climo" in request.inputs:
             climo = list(set([climo.data for climo in request.inputs["climo"]]))

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -190,7 +190,7 @@ class GenerateClimos(Process):
         return list(set(resolutions))
 
     def collect_args(self, request):
-        if("climo" in request.inputs):
+        if "climo" in request.inputs:
             climo = self.format_climo([climo.data for climo in request.inputs["climo"]])
         else:
             climo = standard_climo_periods().keys()

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -194,7 +194,6 @@ class GenerateClimos(Process):
             climo = self.format_climo([climo.data for climo in request.inputs["climo"]])
         else:
             climo = standard_climo_periods().keys()
-        print(climo)
         operation = request.inputs["operation"][0].data
         resolutions = self.format_resolutions(
             [resolution.data for resolution in request.inputs["resolutions"]]

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -251,6 +251,7 @@ class GenerateClimos(Process):
             for period in periods:
                 t_range = input_file.climo_periods[period]
                 create_climo_files(
+                    period,
                     self.workdir,
                     input_file,
                     operation,

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -11,7 +11,7 @@ from pywps.inout.outputs import MetaLink4, MetaFile
 from pywps.app.exceptions import ProcessError
 
 # Tool imports
-from nchelpers import CFDataset
+from nchelpers import CFDataset, standard_climo_periods
 from dp.generate_climos import create_climo_files
 from thunderbird.utils import (
     is_opendap_url,
@@ -59,7 +59,7 @@ class GenerateClimos(Process):
                 "climo",
                 "Climatological Period",
                 abstract="Year ranges",
-                min_occurs=1,
+                min_occurs=0,
                 mode=0,
                 allowed_values=["all"]
                 + [key for key in self.climos.keys()]
@@ -190,7 +190,11 @@ class GenerateClimos(Process):
         return list(set(resolutions))
 
     def collect_args(self, request):
-        climo = self.format_climo([climo.data for climo in request.inputs["climo"]])
+        if("climo" in request.inputs):
+            climo = self.format_climo([climo.data for climo in request.inputs["climo"]])
+        else:
+            climo = standard_climo_periods().keys()
+        print(climo)
         operation = request.inputs["operation"][0].data
         resolutions = self.format_resolutions(
             [resolution.data for resolution in request.inputs["resolutions"]]

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -184,12 +184,12 @@ class GenerateClimos(Process):
         return list(set(resolutions))
 
     def collect_args(self, request):
-        if "climo" in request.input:
+        if "climo" in request.inputs:
             climo = list(set([climo.data for climo in request.inputs["climo"]]))
         else:
             climo = self.climos
 
-        if "resolutions" in request.input:
+        if "resolutions" in request.inputs:
             resolutions = list(
                 set([resolution.data for resolution in request.inputs["resolutions"]])
             )


### PR DESCRIPTION
This PR closes #37 

`wps_generate_climos` has been modified to call `create_climo_files` function with one more argument `climo_period`. Furthermore, if `climo` option is not passed in as an input, it automatically sets `climo =  climo = standard_climo_periods().keys()` to maintain the `generate_climos` behaviors of `ce-dataprep`. Additionally, tests on local_nc files have been added to `test_wps_generate_climos`. 