### PR TITLE
Synchronize run_wps_process throughout all the test files

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,7 @@
 from pkg_resources import resource_filename
+from pywps import Service
 from pywps.app.basic import get_xpath_ns
-from pywps.tests import WpsClient, WpsTestResponse
+from pywps.tests import WpsClient, WpsTestResponse, assert_response_success
 
 import pkg_resources
 
@@ -86,3 +87,17 @@ def get_output(doc):
             output[identifier_el.text] = data_el[0].text
 
     return output
+
+
+def run_wps_process(process, params):
+    client = client_for(Service(processes=[process]))
+    datainputs = params
+    resp = client.get(
+        service="wps",
+        request="Execute",
+        version="1.0.0",
+        identifier=process.identifier,
+        datainputs=datainputs,
+    )
+
+    assert_response_success(resp)

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -7,7 +7,7 @@ from .common import TESTDATA, run_wps_process
 from thunderbird.processes.wps_generate_climos import GenerateClimos
 
 
-def parameters(netcdf, kwargs):
+def build_params(netcdf, kwargs):
     return (
         "netcdf=@xlink:href={0};"
         "operation={operation};"
@@ -52,7 +52,7 @@ def parameters(netcdf, kwargs):
     ],
 )
 def test_wps_gen_climos_opendap(netcdf, kwargs):
-    params = parameters(netcdf, kwargs)
+    params = build_params(netcdf, kwargs)
     run_wps_process(GenerateClimos(), params)
 
 
@@ -93,7 +93,7 @@ local_test_data = [
     ],
 )
 def test_wps_gen_climos_local_nc(netcdf, kwargs):
-    params = parameters(netcdf, kwargs)
+    params = build_params(netcdf, kwargs)
     run_wps_process(GenerateClimos(), params)
 
 

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -3,21 +3,21 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import client_for, TESTDATA
+from .common import TESTDATA, run_wps_process
 from thunderbird.processes.wps_generate_climos import GenerateClimos
 
 
-def run_wps_generate_climos(netcdf, datainputs):
-    client = client_for(Service(processes=[GenerateClimos()]))
-
-    resp = client.get(
-        service="wps",
-        request="Execute",
-        version="1.0.0",
-        identifier="generate_climos",
-        datainputs=datainputs,
-    )
-    assert_response_success(resp)
+def parameters(netcdf, kwargs):
+    return (
+        "netcdf=@xlink:href={0};"
+        "operation={operation};"
+        "climo={climo};"
+        "resolutions={resolutions};"
+        "convert_longitudes={convert_longitudes};"
+        "split_vars={split_vars};"
+        "split_intervals={split_intervals};"
+        "dry_run={dry_run};"
+    ).format(netcdf, **kwargs)
 
 
 @pytest.mark.online
@@ -52,18 +52,8 @@ def run_wps_generate_climos(netcdf, datainputs):
     ],
 )
 def test_wps_gen_climos_opendap(netcdf, kwargs):
-    datainputs = (
-        "netcdf=@xlink:href={0};"
-        "operation={operation};"
-        "climo={climo};"
-        "resolutions={resolutions};"
-        "convert_longitudes={convert_longitudes};"
-        "split_vars={split_vars};"
-        "split_intervals={split_intervals};"
-        "dry_run={dry_run};"
-    ).format(netcdf, **kwargs)
-
-    run_wps_generate_climos(netcdf, datainputs)
+    params = parameters(netcdf, kwargs)
+    run_wps_process(GenerateClimos(), params)
 
 
 # running generate_climos on climo files is againt the purpose of the program
@@ -103,18 +93,8 @@ local_test_data = [
     ],
 )
 def test_wps_gen_climos_local_nc(netcdf, kwargs):
-    datainputs = (
-        "netcdf=@xlink:href={0};"
-        "operation={operation};"
-        "climo={climo};"
-        "resolutions={resolutions};"
-        "convert_longitudes={convert_longitudes};"
-        "split_vars={split_vars};"
-        "split_intervals={split_intervals};"
-        "dry_run={dry_run};"
-    ).format(netcdf, **kwargs)
-
-    run_wps_generate_climos(netcdf, datainputs)
+    params = parameters(netcdf, kwargs)
+    run_wps_process(GenerateClimos(), params)
 
 
 @pytest.mark.parametrize(
@@ -124,9 +104,7 @@ def test_wps_gen_climos_local_nc(netcdf, kwargs):
     ("kwargs"), [({"operation": "mean", "dry_run": "False",}),],
 )
 def test_missing_arguments(netcdf, kwargs):
-    client = client_for(Service(processes=[GenerateClimos()]))
-    datainputs = (
+    params = (
         "netcdf=@xlink:href={0};" "operation={operation};" "dry_run={dry_run};"
     ).format(netcdf, **kwargs)
-
-    run_wps_generate_climos(netcdf, datainputs)
+    run_wps_process(GenerateClimos(), params)

--- a/tests/test_wps_generate_prsn.py
+++ b/tests/test_wps_generate_prsn.py
@@ -7,7 +7,7 @@ from .common import TESTDATA, run_wps_process
 from thunderbird.processes.wps_generate_prsn import GeneratePrsn
 
 
-def parameters(kwargs):
+def build_params(kwargs):
     if (
         "chunk_size" in kwargs.keys() and "output_file" in kwargs.keys()
     ):  # Not using default values
@@ -42,7 +42,7 @@ def parameters(kwargs):
     ],
 )
 def test_default_local(kwargs):
-    params = parameters(kwargs)
+    params = build_params(kwargs)
     run_wps_process(GeneratePrsn(), params)
 
 
@@ -62,7 +62,7 @@ def test_default_local(kwargs):
     ],
 )
 def test_run_local(kwargs):
-    params = parameters(kwargs)
+    params = build_params(kwargs)
     run_wps_process(GeneratePrsn(), params)
 
 
@@ -81,7 +81,7 @@ def test_run_local(kwargs):
     ],
 )
 def test_default_opendap(kwargs):
-    params = parameters(kwargs)
+    params = build_params(kwargs)
     run_wps_process(GeneratePrsn(), params)
 
 
@@ -102,7 +102,7 @@ def test_default_opendap(kwargs):
     ],
 )
 def test_run_opendap(kwargs):
-    params = parameters(kwargs)
+    params = build_params(kwargs)
     run_wps_process(GeneratePrsn(), params)
 
 
@@ -133,5 +133,5 @@ def test_run_opendap(kwargs):
     ],
 )
 def test_run_mixed(kwargs):
-    params = parameters(kwargs)
+    params = build_params(kwargs)
     run_wps_process(GeneratePrsn(), params)

--- a/tests/test_wps_generate_prsn.py
+++ b/tests/test_wps_generate_prsn.py
@@ -3,17 +3,15 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import client_for, TESTDATA
+from .common import TESTDATA, run_wps_process
 from thunderbird.processes.wps_generate_prsn import GeneratePrsn
 
 
-def run_wps_process(kwargs):
-    """Run generate_prsn process using data inputs given by kwargs"""
-    client = client_for(Service(processes=[GeneratePrsn()]))
+def parameters(kwargs):
     if (
         "chunk_size" in kwargs.keys() and "output_file" in kwargs.keys()
     ):  # Not using default values
-        datainputs = (
+        return (
             "prec=@xlink:href={prec};"
             "tasmin=@xlink:href={tasmin};"
             "tasmax=@xlink:href={tasmax};"
@@ -22,20 +20,12 @@ def run_wps_process(kwargs):
             "output_file={output_file};"
         ).format(**kwargs)
     else:
-        datainputs = (
+        return (
             "prec=@xlink:href={prec};"
             "tasmin=@xlink:href={tasmin};"
             "tasmax=@xlink:href={tasmax};"
             "dry_run={dry_run};"
         ).format(**kwargs)
-    resp = client.get(
-        service="wps",
-        request="Execute",
-        version="1.0.0",
-        identifier="generate_prsn",
-        datainputs=datainputs,
-    )
-    assert_response_success(resp)
 
 
 @pytest.mark.parametrize(
@@ -52,7 +42,8 @@ def run_wps_process(kwargs):
     ],
 )
 def test_default_local(kwargs):
-    run_wps_process(kwargs)
+    params = parameters(kwargs)
+    run_wps_process(GeneratePrsn(), params)
 
 
 @pytest.mark.parametrize(
@@ -71,7 +62,8 @@ def test_default_local(kwargs):
     ],
 )
 def test_run_local(kwargs):
-    run_wps_process(kwargs)
+    params = parameters(kwargs)
+    run_wps_process(GeneratePrsn(), params)
 
 
 @pytest.mark.online
@@ -89,7 +81,8 @@ def test_run_local(kwargs):
     ],
 )
 def test_default_opendap(kwargs):
-    run_wps_process(kwargs)
+    params = parameters(kwargs)
+    run_wps_process(GeneratePrsn(), params)
 
 
 @pytest.mark.online
@@ -109,7 +102,8 @@ def test_default_opendap(kwargs):
     ],
 )
 def test_run_opendap(kwargs):
-    run_wps_process(kwargs)
+    params = parameters(kwargs)
+    run_wps_process(GeneratePrsn(), params)
 
 
 @pytest.mark.online
@@ -139,4 +133,5 @@ def test_run_opendap(kwargs):
     ],
 )
 def test_run_mixed(kwargs):
-    run_wps_process(kwargs)
+    params = parameters(kwargs)
+    run_wps_process(GeneratePrsn(), params)

--- a/tests/test_wps_update_metadata.py
+++ b/tests/test_wps_update_metadata.py
@@ -3,25 +3,14 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import client_for, TESTDATA
+from .common import TESTDATA, run_wps_process
 from thunderbird.processes.wps_update_metadata import UpdateMetadata
 import owslib.wps
 import os
 
 
-def run_wps_update_metadata(netcdf, updates):
-    client = client_for(Service(processes=[UpdateMetadata()]))
-    datainputs = ("netcdf=@xlink:href={0};" "updates={1};").format(netcdf, updates)
-
-    resp = client.get(
-        service="wps",
-        request="Execute",
-        version="1.0.0",
-        identifier="update_metadata",
-        datainputs=datainputs,
-    )
-
-    assert_response_success(resp)
+def parameters(netcdf, updates):
+    return ("netcdf=@xlink:href={0};" "updates={1};").format(netcdf, updates)
 
 
 @pytest.mark.online
@@ -32,7 +21,8 @@ def run_wps_update_metadata(netcdf, updates):
     ("updates"), TESTDATA["test_yaml"],
 )
 def test_wps_update_metadata_opendap(netcdf, updates):
-    run_wps_update_metadata(netcdf, updates)
+    params = parameters(netcdf, updates)
+    run_wps_process(UpdateMetadata(), params)
 
 
 @pytest.mark.parametrize(
@@ -42,4 +32,5 @@ def test_wps_update_metadata_opendap(netcdf, updates):
     ("updates"), TESTDATA["test_yaml"],
 )
 def test_wps_update_metadata_netcdf(netcdf, updates):
-    run_wps_update_metadata(netcdf, updates)
+    params = parameters(netcdf, updates)
+    run_wps_process(UpdateMetadata(), params)

--- a/tests/test_wps_update_metadata.py
+++ b/tests/test_wps_update_metadata.py
@@ -9,7 +9,7 @@ import owslib.wps
 import os
 
 
-def parameters(netcdf, updates):
+def build_params(netcdf, updates):
     return ("netcdf=@xlink:href={0};" "updates={1};").format(netcdf, updates)
 
 
@@ -21,7 +21,7 @@ def parameters(netcdf, updates):
     ("updates"), TESTDATA["test_yaml"],
 )
 def test_wps_update_metadata_opendap(netcdf, updates):
-    params = parameters(netcdf, updates)
+    params = build_params(netcdf, updates)
     run_wps_process(UpdateMetadata(), params)
 
 
@@ -32,5 +32,5 @@ def test_wps_update_metadata_opendap(netcdf, updates):
     ("updates"), TESTDATA["test_yaml"],
 )
 def test_wps_update_metadata_netcdf(netcdf, updates):
-    params = parameters(netcdf, updates)
+    params = build_params(netcdf, updates)
     run_wps_process(UpdateMetadata(), params)


### PR DESCRIPTION
This PR "partially" resolves #40 

`run_wps_process()` function in each test files has been refactored into `common.py`. However, the format of parameters tuple could not be synchronized for every test files, thus each test files have their own `parameters()` function.