### PR TITLE
Solve netcdf inconsistency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-pywps>=4.2.0<4.3
-jinja2
-click
-psutil
 ce-dataprep==0.8.2
 cftime==1.1.3
+click
+jinja2
+netCDF4==1.5.3
+psutil
+pywps>=4.2.0<4.3
 xarray==0.15.1


### PR DESCRIPTION
Much of the work to solve the issue was done behind the scenes.  New configuration settings for `ssl` verification, a new `cert` bundle and metadata updates to test files. The only change that was needed on the repo side was to include the newest version of `netCDF4`. This version matches the default version used in `birdhouse-deploy`'s `jupyter` container.  That way our CI/`pytest` tests will be on the same page as the "prod" env.

I encourage reviewers to visit the [jupyter hub](https://docker-dev03.pcic.uvic.ca) instance to test out `thunderbird`. Please notify me if there are any broken files that I missed. 

Resolves #41.