### PR TITLE
Removed `/tests` from pytest command-line-options-defaults(addopts) to make specific test definition available.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ replace = Version="{new_version}"
 addopts =
 	--strict
 	--tb=native
-	tests/
 python_files = test_*.py
 markers =
 	online: mark test to need internet connection


### PR DESCRIPTION
This PR resolves #34 

It looks like the pytest's default command line option `/tests` in `setup.cfg` restrained us to test on specific tests defined as `pytest tests/test_*.py`. Removing this [line](https://github.com/pacificclimate/thunderbird/compare/i34-define-specific-test#diff-380c6a8ebbbce17d55d50ef17d3cf906L31) should solve the problem. However, I wonder if there were any particular reasons that the option was included, so please let me know if it must be included. Following is an example pytest run on `tests/test_wps_update_metadata.py::test_wps_update_metadata_opendap`:
```
slim@devel2:~/Desktop/thunderbird$ pytest tests/test_wps_update_metadata.py::test_wps_update_metadata_opendap
============================================= test session starts ==============================================
platform linux -- Python 3.7.5, pytest-5.4.3, py-1.5.2, pluggy-0.13.1
rootdir: /home/slim/Desktop/thunderbird, inifile: setup.cfg
collected 6 items                                                                                              

tests/test_wps_update_metadata.py ......                                                                 [100%]

=============================================== warnings summary ===============================================
/usr/lib/python3/dist-packages/markupsafe/__init__.py:13
  /usr/lib/python3/dist-packages/markupsafe/__init__.py:13: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping

/usr/lib/python3/dist-packages/urllib3/_collections.py:2
  /usr/lib/python3/dist-packages/urllib3/_collections.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping, MutableMapping

/usr/lib/python3/dist-packages/babel/core.py:1129
  /usr/lib/python3/dist-packages/babel/core.py:1129: DeprecationWarning: invalid escape sequence \s
    """

/usr/lib/python3/dist-packages/yaml/constructor.py:126
  /usr/lib/python3/dist-packages/yaml/constructor.py:126: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    if not isinstance(key, collections.Hashable):

tests/test_wps_update_metadata.py::test_wps_update_metadata_opendap[/home/slim/Desktop/thunderbird/tests/metadata-conversion/updates-CLIMDEX-downscale-BCCAQ.yaml-http://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc]
  /usr/lib/python3/dist-packages/requests/models.py:177: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    if isinstance(hook, collections.Callable):

tests/test_wps_update_metadata.py::test_wps_update_metadata_opendap[/home/slim/Desktop/thunderbird/tests/metadata-conversion/updates-CLIMDEX-downscale-BCCAQ.yaml-http://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc]
  /home/slim/.local/lib/python3.7/site-packages/nchelpers/__init__.py:979: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    elif isinstance(dim_names, collections.Iterable):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================== 6 passed, 6 warnings in 114.39s (0:01:54) ===================================
[1]+  Killed                  pytest tests/test_wps_update_metadata.py

```