### PR TITLE
Update docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   wps:
     build: .
-    image: pacificclimate/thunderbird
+    image: pcic/thunderbird
     ports:
       - "8099:5001"
 


### PR DESCRIPTION
Tiniest of changes but this just ensures the `docker-compose` can run the app in isolation from the `pavics-component`.