### PR TITLE
Remove OS package causing scan failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,11 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* && \
     # this line combats the issue found here:
     # https://superuser.com/questions/1347723/arch-on-wsl-libqt5core-so-5-not-found-despite-being-installed
-    strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
+    strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 && \
+    # Removing this package prevents a scan failure. It will be reintroduced
+    # once 1.24.2 becomes available through the base image.
+    # Issue link: https://github.com/advisories/GHSA-mh33-7rrq-662w
+    apt-get remove -y python3-urllib3
 
 WORKDIR /code
 


### PR DESCRIPTION
This resolves #79 by removing the package causing the problem.  I have tested a `thunderbird` instance running with this package removed and had no issues.