### PR TITLE
Utilize newly implemented functions in ce-dataprep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ce-dataprep==0.8.3
+ce-dataprep==0.8.4
 cftime==1.1.3
 click
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ce-dataprep==0.8.4
+ce-dataprep==0.8.5
 cftime==1.1.3
 click
 jinja2

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -26,7 +26,6 @@ from thunderbird.wps_io import (
 
 # Library imports
 import logging
-import sys
 import os
 
 

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -129,6 +129,13 @@ class GenerateClimos(Process):
         )
 
     def dry_run_info(self, filepath, climo):
+        '''
+        This function creates an output file with "_dry.txt" at the end.
+        logging.basicConfig() is used to redirect messages logged from
+        generate_climos's dry_run_handler to the created file. After dry_run
+        is processed, logging.root.removeHandler(handler) resets logging 
+        configuration to redirect further logging messages to terminal.
+        '''
         filename = os.path.basename(filepath).split(".")[
             0
         ]  # Uniquely identify each dry run file

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -9,7 +9,7 @@ from pywps.app.Common import Metadata
 
 # Tool imports
 from nchelpers import CFDataset, standard_climo_periods
-from dp.generate_climos import create_climo_files, dry_run_handler
+from dp.generate_climos import generate_climos, dry_run_handler
 from thunderbird.utils import (
     MAX_OCCURS,
     get_filepaths,
@@ -213,10 +213,6 @@ class GenerateClimos(Process):
             del response.outputs["dry_output"]  # remove unnecessary output
             response.update_status("Processing filepaths", 10)
             for filepath in filepaths:
-                input_file = CFDataset(filepath)
-
-                periods = [period for period in input_file.climo_periods.keys() & climo]
-
                 log_handler(
                     self,
                     response,
@@ -224,18 +220,17 @@ class GenerateClimos(Process):
                     process_step="process",
                     level=loglevel,
                 )
-                for period in periods:
-                    t_range = input_file.climo_periods[period]
-                    create_climo_files(
-                        period,
-                        self.workdir,
-                        input_file,
-                        operation,
-                        *t_range,
-                        convert_longitudes=convert_longitudes,
-                        split_vars=split_vars,
-                        output_resolutions=resolutions,
-                    )
+
+                generate_climos(
+                    filepath,
+                    self.workdir,
+                    operation,
+                    climo,
+                    convert_longitudes=convert_longitudes,
+                    split_vars=split_vars,
+                    split_intervals=split_intervals,
+                    resolutions=resolutions,
+                )
 
             log_handler(
                 self,

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -139,7 +139,8 @@ class GenerateClimos(Process):
             f.write("Dry Run\n")
             logging.basicConfig(filename=filename, level=logging.INFO)
             dry_run_handler(filepath, climo)
-            logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+            for handler in logging.root.handlers[:]:
+                logging.root.removeHandler(handler)
 
         return filename
 


### PR DESCRIPTION
This PR closes #76 

`wps_genereate_climos` now uses the same strategy of `generate_climos` script of `ce-dataprep`.
`dry_run_handler` and `generate_climos` functions are imported from `dp` package and replace the functionally equivalent codes in `self._handler`.

There was an issue that the previous version of `ce-dataprep` did not pass `split_intervals` argument into `create_climo_files`. It has been resolved in the latest version 0.8.4 by implementing `generate_climos` function. Therefore, calling the function also resolves #68

For dry_run, logging messages of `dry_run_handler` are redirected to the output `.txt` file, and an example looks like below:
```
Dry Run
generate_climos:
INFO:dp.generate_climos:Processing: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc
INFO:dp.generate_climos:climo_periods: {'6190'}
INFO:dp.generate_climos:project: CMIP5
INFO:dp.generate_climos:institution: PCIC
INFO:dp.generate_climos:model: CanESM2
INFO:dp.generate_climos:emissions: historical, rcp85
INFO:dp.generate_climos:run: r1i1p1
INFO:dp.generate_climos:dependent_varnames: ['fdd']
INFO:dp.generate_climos:time_resolution: seasonal
INFO:dp.generate_climos:is_multi_year_mean: False
```