### PR TITLE
generate_prsn's dry_run logging messages are redirected to dry.txt

### DIFF
--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -17,6 +17,7 @@ from thunderbird.utils import (
     build_meta_link,
     log_handler,
     dry_run_info,
+    dry_output_filename,
 )
 from thunderbird.wps_io import (
     dryrun_input,
@@ -164,11 +165,6 @@ class GenerateClimos(Process):
             loglevel,
         )
 
-    def dry_output_filename(self, filepath):
-        return os.path.join(
-            self.workdir, os.path.basename(filepath).split(".")[0] + "_dry.txt",
-        )
-
     def _handler(self, request, response):
         (
             climo,
@@ -192,7 +188,7 @@ class GenerateClimos(Process):
             del response.outputs["output"]  # remove unnecessary output
             dry_files = [
                 dry_run_info(
-                    self.dry_output_filename(filepath),
+                    dry_output_filename(self.workdir, filepath),
                     dry_run_handler,
                     filepath=filepath,
                     climo=climo,

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -168,7 +168,7 @@ class GenerateClimos(Process):
         return os.path.join(
             self.workdir,
             os.path.basename(filepath).split(".")[0] + "_dry.txt",
-        ),
+        )
 
     def _handler(self, request, response):
         (

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -166,8 +166,7 @@ class GenerateClimos(Process):
 
     def dry_output_filename(self, filepath):
         return os.path.join(
-            self.workdir,
-            os.path.basename(filepath).split(".")[0] + "_dry.txt",
+            self.workdir, os.path.basename(filepath).split(".")[0] + "_dry.txt",
         )
 
     def _handler(self, request, response):

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -164,6 +164,12 @@ class GenerateClimos(Process):
             loglevel,
         )
 
+    def dry_output_filename(self, filepath):
+        return os.path.join(
+            self.workdir,
+            os.path.basename(filepath).split(".")[0] + "_dry.txt",
+        ),
+
     def _handler(self, request, response):
         (
             climo,
@@ -187,10 +193,7 @@ class GenerateClimos(Process):
             del response.outputs["output"]  # remove unnecessary output
             dry_files = [
                 dry_run_info(
-                    os.path.join(
-                        self.workdir,
-                        os.path.basename(filepath).split(".")[0] + "_dry.txt",
-                    ),
+                    self.dry_output_filename(filepath),
                     dry_run_handler,
                     filepath=filepath,
                     climo=climo,

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -16,6 +16,7 @@ from thunderbird.utils import (
     collect_output_files,
     build_meta_link,
     log_handler,
+    dry_run_info,
 )
 from thunderbird.wps_io import (
     dryrun_input,
@@ -128,28 +129,6 @@ class GenerateClimos(Process):
             status_supported=True,
         )
 
-    def dry_run_info(self, filepath, climo):
-        '''
-        This function creates an output file with "_dry.txt" at the end.
-        logging.basicConfig() is used to redirect messages logged from
-        generate_climos's dry_run_handler to the created file. After dry_run
-        is processed, logging.root.removeHandler(handler) resets logging 
-        configuration to redirect further logging messages to terminal.
-        '''
-        filename = os.path.basename(filepath).split(".")[
-            0
-        ]  # Uniquely identify each dry run file
-        filename += "_dry.txt"
-        filename = os.path.join(self.workdir, filename)
-        with open(filename, "w") as f:
-            f.write("Dry Run\n")
-            logging.basicConfig(filename=filename, level=logging.INFO)
-            dry_run_handler(filepath, climo)
-            for handler in logging.root.handlers[:]:
-                logging.root.removeHandler(handler)
-
-        return filename
-
     def get_identifier(self, operation):
         """Use operation in filename to indicate that it is an output file"""
         suffix = {"mean": "Mean", "std": "SD"}[operation]
@@ -206,7 +185,18 @@ class GenerateClimos(Process):
         if dry_run:
             log_handler(self, response, "Dry Run", process_step="dry_run")
             del response.outputs["output"]  # remove unnecessary output
-            dry_files = [self.dry_run_info(filepath, climo) for filepath in filepaths]
+            dry_files = [
+                dry_run_info(
+                    os.path.join(
+                        self.workdir,
+                        os.path.basename(filepath).split(".")[0] + "_dry.txt",
+                    ),
+                    dry_run_handler,
+                    filepath=filepath,
+                    climo=climo,
+                )
+                for filepath in filepaths
+            ]
 
             response.outputs["dry_output"].data = build_meta_link(
                 varname="dry_run",

--- a/thunderbird/processes/wps_generate_prsn.py
+++ b/thunderbird/processes/wps_generate_prsn.py
@@ -151,8 +151,7 @@ class GeneratePrsn(Process):
                 self, response, "Dry Run", process_step="dry_run", level=loglevel
             )
             del response.outputs["output"]  # remove unnecessary output
-            filename = os.path.join(self.workdir, "dry.txt")
-            dry_file = dry_run_info(filename, dry_run_handler, filepaths=filepaths)
+            dry_file = dry_run_info(os.path.join(self.workdir, "dry.txt"), dry_run_handler, filepaths=filepaths)
             response.outputs["dry_output"].file = dry_file
 
         else:

--- a/thunderbird/processes/wps_generate_prsn.py
+++ b/thunderbird/processes/wps_generate_prsn.py
@@ -17,6 +17,7 @@ from thunderbird.utils import (
     build_meta_link,
     log_handler,
     dry_run_info,
+    dry_output_filename,
 )
 from thunderbird.wps_io import (
     log_level,
@@ -152,7 +153,7 @@ class GeneratePrsn(Process):
             )
             del response.outputs["output"]  # remove unnecessary output
             dry_file = dry_run_info(
-                os.path.join(self.workdir, "dry.txt"),
+                dry_output_filename(self.workdir, "prsn_dry.txt"),
                 dry_run_handler,
                 filepaths=filepaths,
             )

--- a/thunderbird/processes/wps_generate_prsn.py
+++ b/thunderbird/processes/wps_generate_prsn.py
@@ -151,7 +151,11 @@ class GeneratePrsn(Process):
                 self, response, "Dry Run", process_step="dry_run", level=loglevel
             )
             del response.outputs["output"]  # remove unnecessary output
-            dry_file = dry_run_info(os.path.join(self.workdir, "dry.txt"), dry_run_handler, filepaths=filepaths)
+            dry_file = dry_run_info(
+                os.path.join(self.workdir, "dry.txt"),
+                dry_run_handler,
+                filepaths=filepaths,
+            )
             response.outputs["dry_output"].file = dry_file
 
         else:

--- a/thunderbird/utils.py
+++ b/thunderbird/utils.py
@@ -125,3 +125,21 @@ def log_handler(process, response, message, process_step=None, level="INFO"):
     pywps_logger.log(getattr(logging, level), message)
     stderr_logger.log(getattr(logging, level), message)
     response.update_status(message, status_percentage=status_percentage)
+
+
+def dry_run_info(filename, dry_run_method, **kwargs):
+    """
+    This function creates an output file with the given filename.
+    logging.basicConfig() is used to redirect messages logged from
+    dry_run_method to the created file. After dry_run is processed,
+    logging.root.removeHandler(handler) resets logging configuration
+    to redirect further logging messages to terminal.
+    """
+    with open(filename, "w") as f:
+        f.write("Dry Run\n")
+        logging.basicConfig(filename=filename, level=logging.INFO)
+        dry_run_method(**kwargs)
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+
+    return filename

--- a/thunderbird/utils.py
+++ b/thunderbird/utils.py
@@ -143,3 +143,12 @@ def dry_run_info(filename, dry_run_method, **kwargs):
             logging.root.removeHandler(handler)
 
     return filename
+
+
+def dry_output_filename(outdir, filename):
+    if filename.endswith(".nc"):
+        return os.path.join(
+            outdir, os.path.basename(filename).split(".")[0] + "_dry.txt",
+        )
+    else:
+        return os.path.join(outdir, filename)


### PR DESCRIPTION
This PR closes #82 

`wps_generate_prsn`'s dry_run output strategy now follows `wps_generate_climos`. Since they are using a similar method, `dry_run_info` function is moved to `utils.py`.