### PR TITLE
validate test_wps_generate_climos inputs

### DIFF
--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -10,10 +10,7 @@ from thunderbird.processes.wps_generate_climos import GenerateClimos
 local_test_data = [
     local_path(nc)
     for nc in TESTDATA["test_local_nc"]
-    if nc.startswith("tiny_")
-    and not nc.endswith("_climos.nc")
-    and "_gcm" not in nc
-    and "_downscaled" not in nc
+    if nc.startswith("tiny_") and not nc.endswith("_climos.nc") and "_gcm" not in nc
 ]
 # NetCDFs with flow_vectors not adequate for generate_climos
 # refer to https://github.com/pacificclimate/climate-explorer-data-prep#generate_climos-generate-climatological-means
@@ -147,7 +144,7 @@ def test_wps_gen_climos_opendap_multiple(netcdf, kwargs):
         (
             {
                 "operation": "std",
-                "climo": "7100",
+                "climo": "6190",
                 "resolutions": "monthly",
                 "convert_longitudes": "False",
                 "split_vars": "False",

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -10,7 +10,10 @@ from thunderbird.processes.wps_generate_climos import GenerateClimos
 local_test_data = [
     local_path(nc)
     for nc in TESTDATA["test_local_nc"]
-    if nc.startswith("tiny_") and not nc.endswith("_climos.nc")
+    if nc.startswith("tiny_")
+    and not nc.endswith("_climos.nc")
+    and "_gcm" not in nc
+    and "_downscaled" not in nc
 ]
 # NetCDFs with flow_vectors not adequate for generate_climos
 # refer to https://github.com/pacificclimate/climate-explorer-data-prep#generate_climos-generate-climatological-means


### PR DESCRIPTION
This PR close #84 

After manually running `generate_climos` on every single `tiny` file, I have figured `gcm` data do not have standard climo periods, which makes them not adequate for `generate_climos` run. Also, some local `NetCDF` files do not have `7100` climo period, hence it is replaced by `6190`.