### PR TITLE
Use updated log_handler and create thunderbird logger

### DIFF
--- a/notebooks/demo_processes.ipynb
+++ b/notebooks/demo_processes.ipynb
@@ -57,7 +57,7 @@
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f8b34081400>\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f62e41405c0>\n",
        "\u001b[0;31mFile:\u001b[0m            ~/thunderbird-venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Explorer data preparation\n",
@@ -76,9 +76,6 @@
        "\n",
        "split_merged_climos\n",
        "    Split climo means files into one file per time interval\n",
-       "\n",
-       "hello\n",
-       "    Just says a friendly Hello.Returns a literal string output with Hello plus the inputed name.\n",
        "\n",
        "decompose_flow_vectors\n",
        "    Process an indexed flow direction netCDF into a vectored netCDF suitable for ncWMS display\n",
@@ -148,6 +145,7 @@
        "\u001b[0;34m\u001b[0m    \u001b[0mconvert_longitudes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0msplit_vars\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0msplit_intervals\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mclimo\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mresolutions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
@@ -172,6 +170,8 @@
        "    Generate a separate file for each climatological period\n",
        "dry_run : boolean\n",
        "    Checks file to ensure compatible with process\n",
+       "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
+       "    Logging level\n",
        "\n",
        "Returns\n",
        "-------\n",
@@ -224,7 +224,7 @@
      "data": {
       "text/plain": [
        "<metaurl mediatype=\"text/plain\">\n",
-       "     http://localhost:5001/outputs/567cc511-bb23-11ea-afd0-c86000e3f2fd/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt\n",
+       "     http://localhost:5001/outputs/b8755a79-dd85-11ea-a870-c86000e3f2fd/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt\n",
        "    </metaurl>"
       ]
      },
@@ -264,7 +264,7 @@
      "data": {
       "text/plain": [
        "<metaurl mediatype=\"application/x-netcdf\">\n",
-       "     http://localhost:5001/outputs/5d8580cc-bb23-11ea-afd0-c86000e3f2fd/fdd_aClimMean_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231_Canada.nc\n",
+       "     http://localhost:5001/outputs/bf715cfa-dd85-11ea-a870-c86000e3f2fd/fdd_aClimMean_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231_Canada.nc\n",
        "    </metaurl>"
       ]
      },
@@ -304,10 +304,10 @@
      "data": {
       "text/plain": [
        "[<metaurl mediatype=\"text/plain\">\n",
-       "      http://localhost:5001/outputs/5d8d4a5b-bb23-11ea-afd0-c86000e3f2fd/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt\n",
+       "      http://localhost:5001/outputs/bf786edd-dd85-11ea-a870-c86000e3f2fd/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt\n",
        "     </metaurl>,\n",
        " <metaurl mediatype=\"text/plain\">\n",
-       "      http://localhost:5001/outputs/5d8d4a5c-bb23-11ea-afd0-c86000e3f2fd/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt\n",
+       "      http://localhost:5001/outputs/bf786ede-dd85-11ea-a870-c86000e3f2fd/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt\n",
        "     </metaurl>]"
       ]
      },
@@ -345,10 +345,10 @@
      "data": {
       "text/plain": [
        "[<metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/639f10d6-bb23-11ea-afd0-c86000e3f2fd/gdd_aClimMean_CanESM2_rcp85_r1i1p1_19610101-19901231.nc\n",
+       "      http://localhost:5001/outputs/c6343e04-dd85-11ea-a870-c86000e3f2fd/gdd_aClimMean_CanESM2_rcp85_r1i1p1_19610101-19901231.nc\n",
        "     </metaurl>,\n",
        " <metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/639f10d7-bb23-11ea-afd0-c86000e3f2fd/fdd_aClimMean_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231_Canada.nc\n",
+       "      http://localhost:5001/outputs/c6343e05-dd85-11ea-a870-c86000e3f2fd/fdd_aClimMean_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231_Canada.nc\n",
        "     </metaurl>]"
       ]
      },
@@ -434,22 +434,22 @@
      "data": {
       "text/plain": [
        "[<metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/64c9f3b8-bb23-11ea-afd0-c86000e3f2fd/tasmax_mClim_BCCAQ2_ACCESS1-0_historical+rcp45_r1i1p1_19610101-19901231.nc\n",
+       "      http://localhost:5001/outputs/c76ac1e4-dd85-11ea-a870-c86000e3f2fd/tasmax_mClim_BCCAQ2_ACCESS1-0_historical+rcp45_r1i1p1_19610101-19901231.nc\n",
        "     </metaurl>,\n",
        " <metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/64c9f3b9-bb23-11ea-afd0-c86000e3f2fd/tasmax_sClim_BCCAQ2_ACCESS1-0_historical+rcp45_r1i1p1_19610101-19901231.nc\n",
+       "      http://localhost:5001/outputs/c76ac1e5-dd85-11ea-a870-c86000e3f2fd/tasmax_sClim_BCCAQ2_ACCESS1-0_historical+rcp45_r1i1p1_19610101-19901231.nc\n",
        "     </metaurl>,\n",
        " <metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/64c9f3ba-bb23-11ea-afd0-c86000e3f2fd/tasmax_aClim_BCCAQ2_ACCESS1-0_historical+rcp45_r1i1p1_19610101-19901231.nc\n",
+       "      http://localhost:5001/outputs/c76ac1e6-dd85-11ea-a870-c86000e3f2fd/tasmax_aClim_BCCAQ2_ACCESS1-0_historical+rcp45_r1i1p1_19610101-19901231.nc\n",
        "     </metaurl>,\n",
        " <metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/64c9f3bb-bb23-11ea-afd0-c86000e3f2fd/BASEFLOW+EVAP+GLAC_AREA_BAND+GLAC_MBAL_BAND+RUNOFF+SWE_BAND_mClim_VICGL+RGM+HydroCon_ACCESS1-0_historical+rcp45_r1i1p1_19840101-19951231.nc\n",
+       "      http://localhost:5001/outputs/c76ac1e7-dd85-11ea-a870-c86000e3f2fd/BASEFLOW+EVAP+GLAC_AREA_BAND+GLAC_MBAL_BAND+RUNOFF+SWE_BAND_mClim_VICGL+RGM+HydroCon_ACCESS1-0_historical+rcp45_r1i1p1_19840101-19951231.nc\n",
        "     </metaurl>,\n",
        " <metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/64c9f3bc-bb23-11ea-afd0-c86000e3f2fd/BASEFLOW+EVAP+GLAC_AREA_BAND+GLAC_MBAL_BAND+RUNOFF+SWE_BAND_sClim_VICGL+RGM+HydroCon_ACCESS1-0_historical+rcp45_r1i1p1_19840101-19951231.nc\n",
+       "      http://localhost:5001/outputs/c76ac1e8-dd85-11ea-a870-c86000e3f2fd/BASEFLOW+EVAP+GLAC_AREA_BAND+GLAC_MBAL_BAND+RUNOFF+SWE_BAND_sClim_VICGL+RGM+HydroCon_ACCESS1-0_historical+rcp45_r1i1p1_19840101-19951231.nc\n",
        "     </metaurl>,\n",
        " <metaurl mediatype=\"application/x-netcdf\">\n",
-       "      http://localhost:5001/outputs/64c9f3bd-bb23-11ea-afd0-c86000e3f2fd/BASEFLOW+EVAP+GLAC_AREA_BAND+GLAC_MBAL_BAND+RUNOFF+SWE_BAND_aClim_VICGL+RGM+HydroCon_ACCESS1-0_historical+rcp45_r1i1p1_19840101-19951231.nc\n",
+       "      http://localhost:5001/outputs/c76ac1e9-dd85-11ea-a870-c86000e3f2fd/BASEFLOW+EVAP+GLAC_AREA_BAND+GLAC_MBAL_BAND+RUNOFF+SWE_BAND_aClim_VICGL+RGM+HydroCon_ACCESS1-0_historical+rcp45_r1i1p1_19840101-19951231.nc\n",
        "     </metaurl>]"
       ]
      },
@@ -485,7 +485,7 @@
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mthunderbird\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mupdate_metadata\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnetcdf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mupdates\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mthunderbird\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mupdate_metadata\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnetcdf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mupdates\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Update file containing missing, invalid, or incorrectly named global or variable metadata attributes\n",
        "\n",
@@ -495,6 +495,8 @@
        "    NetCDF file\n",
        "updates : string\n",
        "    The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file\n",
+       "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
+       "    Logging level\n",
        "\n",
        "Returns\n",
        "-------\n",
@@ -534,7 +536,7 @@
      "output_type": "stream",
      "text": [
       "update_metadataResponse(\n",
-      "    output='http://localhost:5001/outputs/64d326b8-bb23-11ea-afd0-c86000e3f2fd/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100_copy.nc'\n",
+      "    output='http://localhost:5001/outputs/c7729b1c-dd85-11ea-a870-c86000e3f2fd/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100_copy.nc'\n",
       ")\n"
      ]
     }
@@ -638,27 +640,31 @@
      "output_type": "stream",
      "text": [
       "Dry Run\n",
-      "File: /tmp/pywps_process_1km10ib1/pr_week_test.nc\n",
-      "project: CMIP5\n",
-      "model: NorESM1-M\n",
-      "institute: PCIC\n",
-      "experiment: historical,rcp26\n",
-      "ensemble_member: r1i1p1\n",
-      "dependent_varnames: ['pr']\n",
-      "File: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/tasmin_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\n",
-      "project: CMIP5\n",
-      "model: NorESM1-M\n",
-      "institute: PCIC\n",
-      "experiment: historical,rcp26\n",
-      "ensemble_member: r1i1p1\n",
-      "dependent_varnames: ['tasmin']\n",
-      "File: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/tasmax_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\n",
-      "project: CMIP5\n",
-      "model: NorESM1-M\n",
-      "institute: PCIC\n",
-      "experiment: historical,rcp26\n",
-      "ensemble_member: r1i1p1\n",
-      "dependent_varnames: ['tasmax']\n",
+      "generate_prsn:Dry Run\n",
+      "INFO:dp.generate_prsn:\n",
+      "INFO:dp.generate_prsn:File: /tmp/pywps_process_qhrw6qlv/pr_week_test.nc\n",
+      "INFO:dp.generate_prsn:project: CMIP5\n",
+      "INFO:dp.generate_prsn:model: NorESM1-M\n",
+      "INFO:dp.generate_prsn:institute: PCIC\n",
+      "INFO:dp.generate_prsn:experiment: historical,rcp26\n",
+      "INFO:dp.generate_prsn:ensemble_member: r1i1p1\n",
+      "INFO:dp.generate_prsn:dependent_varnames: ['pr']\n",
+      "INFO:dp.generate_prsn:\n",
+      "INFO:dp.generate_prsn:File: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/tasmin_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\n",
+      "INFO:dp.generate_prsn:project: CMIP5\n",
+      "INFO:dp.generate_prsn:model: NorESM1-M\n",
+      "INFO:dp.generate_prsn:institute: PCIC\n",
+      "INFO:dp.generate_prsn:experiment: historical,rcp26\n",
+      "INFO:dp.generate_prsn:ensemble_member: r1i1p1\n",
+      "INFO:dp.generate_prsn:dependent_varnames: ['tasmin']\n",
+      "INFO:dp.generate_prsn:\n",
+      "INFO:dp.generate_prsn:File: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/tasmax_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\n",
+      "INFO:dp.generate_prsn:project: CMIP5\n",
+      "INFO:dp.generate_prsn:model: NorESM1-M\n",
+      "INFO:dp.generate_prsn:institute: PCIC\n",
+      "INFO:dp.generate_prsn:experiment: historical,rcp26\n",
+      "INFO:dp.generate_prsn:ensemble_member: r1i1p1\n",
+      "INFO:dp.generate_prsn:dependent_varnames: ['tasmax']\n",
       "\n"
      ]
     }
@@ -687,7 +693,7 @@
      "output_type": "stream",
      "text": [
       "generate_prsnResponse(\n",
-      "    output='http://localhost:5001/outputs/67a91852-bb23-11ea-afd0-c86000e3f2fd/prsn_test_mixed.nc'\n",
+      "    output='http://localhost:5001/outputs/cae52b7a-dd85-11ea-a870-c86000e3f2fd/prsn_test_mixed.nc'\n",
       ")\n"
      ]
     }
@@ -718,7 +724,13 @@
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mthunderbird\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecompose_flow_vectors\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnetcdf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvariable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdest_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0mthunderbird\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecompose_flow_vectors\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mnetcdf\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mvariable\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mdest_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Process an indexed flow direction netCDF into a vectored netCDF suitable for ncWMS display\n",
        "\n",
@@ -730,12 +742,14 @@
        "    netCDF variable describing flow direction\n",
        "dest_file : string\n",
        "    destination netCDF file\n",
+       "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
+       "    Logging level\n",
        "\n",
        "Returns\n",
        "-------\n",
        "output : ComplexData:mimetype:`application/x-netcdf`\n",
        "    output netCDF file\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/thunderbird/</home/slim/thunderbird-venv/lib/python3.6/site-packages/birdy/client/base.py-5>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/thunderbird/</home/slim/thunderbird-venv/lib/python3.6/site-packages/birdy/client/base.py-4>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -769,7 +783,7 @@
      "data": {
       "text/plain": [
        "decompose_flow_vectorsResponse(\n",
-       "    output='http://localhost:5001/outputs/6b32a632-bb23-11ea-afd0-c86000e3f2fd/output.nc'\n",
+       "    output='http://localhost:5001/outputs/ce1adf6a-dd85-11ea-a870-c86000e3f2fd/output.nc'\n",
        ")"
       ]
      },

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ psutil==5.7.0
 pywps==4.2.6
 xarray==0.15.1
 nchelpers==5.5.7
-wps-tools==0.1.1
+wps-tools==0.1.2

--- a/thunderbird/processes/wps_decompose_flow_vectors.py
+++ b/thunderbird/processes/wps_decompose_flow_vectors.py
@@ -20,6 +20,7 @@ from dp.decompose_flow_vectors import (
 from pywps.app.exceptions import ProcessError
 from wps_tools.utils import is_opendap_url, log_handler
 from wps_tools.io import log_level
+from thunderbird.utils import logger
 
 
 class DecomposeFlowVectors(Process):
@@ -84,7 +85,12 @@ class DecomposeFlowVectors(Process):
     def _handler(self, request, response):
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
-            self, response, "Starting Process", process_step="start", log_level=loglevel
+            self,
+            response,
+            "Starting Process",
+            logger,
+            log_level=loglevel,
+            process_step="start",
         )
 
         source_file = self.get_filepath(request)
@@ -97,8 +103,9 @@ class DecomposeFlowVectors(Process):
             self,
             response,
             f"Checking {source_file} and {variable}",
-            process_step="input_check",
+            logger,
             log_level=loglevel,
+            process_step="input_check",
         )
         try:
             source_check(source)
@@ -110,8 +117,9 @@ class DecomposeFlowVectors(Process):
             self,
             response,
             "Decomposing flow direction vectors into grids",
-            process_step="process",
+            logger,
             log_level=loglevel,
+            process_step="process",
         )
         decompose_flow_vectors(source, dest_file, variable)
 
@@ -119,8 +127,9 @@ class DecomposeFlowVectors(Process):
             self,
             response,
             "Building final output",
-            process_step="build_output",
+            logger,
             log_level=loglevel,
+            process_step="build_output",
         )
         response.outputs["output"].file = dest_file
 
@@ -128,8 +137,8 @@ class DecomposeFlowVectors(Process):
             self,
             response,
             "Process Complete",
-            process_step="complete",
+            logger,
             log_level=loglevel,
+            process_step="complete",
         )
-        response.update_status("Process Complete", 100)
         return response

--- a/thunderbird/processes/wps_generate_climos.py
+++ b/thunderbird/processes/wps_generate_climos.py
@@ -23,7 +23,7 @@ from wps_tools.io import (
     meta4_dryrun_output,
     log_level,
 )
-from thunderbird.utils import dry_run_info, dry_output_filename
+from thunderbird.utils import logger, dry_run_info, dry_output_filename
 
 # Library import
 import os
@@ -176,13 +176,23 @@ class GenerateClimos(Process):
         ) = self.collect_args(request)
 
         log_handler(
-            self, response, "Starting Process", process_step="start", log_level=loglevel
+            self,
+            response,
+            "Starting Process",
+            logger,
+            log_level=loglevel,
+            process_step="start",
         )
 
         filepaths = get_filepaths(request.inputs["netcdf"])
         if dry_run:
             log_handler(
-                self, response, "Dry Run", process_step="dry_run", log_level=loglevel
+                self,
+                response,
+                "Dry Run",
+                logger,
+                log_level=loglevel,
+                process_step="dry_run",
             )
             del response.outputs["output"]  # remove unnecessary output
             dry_files = [
@@ -211,8 +221,9 @@ class GenerateClimos(Process):
                     self,
                     response,
                     f"Processing {filepath} into climatologies",
-                    process_step="process",
+                    logger,
                     log_level=loglevel,
+                    process_step="process",
                 )
 
                 generate_climos(
@@ -230,8 +241,9 @@ class GenerateClimos(Process):
                 self,
                 response,
                 "Collecting climo files",
-                process_step="collect_files",
+                logger,
                 log_level=loglevel,
+                process_step="collect_files",
             )
 
             climo_files = collect_output_files(
@@ -242,8 +254,9 @@ class GenerateClimos(Process):
                 self,
                 response,
                 "Building final output",
-                process_step="build_output",
+                logger,
                 log_level=loglevel,
+                process_step="build_output",
             )
             response.outputs["output"].data = build_meta_link(
                 varname="climo",
@@ -256,7 +269,8 @@ class GenerateClimos(Process):
             self,
             response,
             "Process Complete",
-            process_step="complete",
+            logger,
             log_level=loglevel,
+            process_step="complete",
         )
         return response

--- a/thunderbird/processes/wps_generate_prsn.py
+++ b/thunderbird/processes/wps_generate_prsn.py
@@ -23,7 +23,7 @@ from wps_tools.io import (
     nc_output,
     dryrun_output,
 )
-from thunderbird.utils import dry_run_info, dry_output_filename
+from thunderbird.utils import logger, dry_run_info, dry_output_filename
 
 
 # Library import
@@ -141,14 +141,24 @@ class GeneratePrsn(Process):
     def _handler(self, request, response):
         (chunk_size, loglevel, dry_run, output_file) = self.collect_args(request)
         log_handler(
-            self, response, "Starting Process", process_step="start", log_level=loglevel
+            self,
+            response,
+            "Starting Process",
+            logger,
+            log_level=loglevel,
+            process_step="start",
         )
 
         filepaths = self.get_filepaths(request)
 
         if dry_run:
             log_handler(
-                self, response, "Dry Run", process_step="dry_run", log_level=loglevel
+                self,
+                response,
+                "Dry Run",
+                logger,
+                log_level=loglevel,
+                process_step="dry_run",
             )
             del response.outputs["output"]  # remove unnecessary output
             dry_file = dry_run_info(
@@ -165,8 +175,9 @@ class GeneratePrsn(Process):
                 self,
                 response,
                 f"Processing {filepaths} into snowfall fluxes",
-                process_step="process",
+                logger,
                 log_level=loglevel,
+                process_step="process",
             )
             generate_prsn_file(filepaths, chunk_size, self.workdir, output_file)
 
@@ -174,8 +185,9 @@ class GeneratePrsn(Process):
                 self,
                 response,
                 "Collecting snowfall files",
-                process_step="collect_files",
+                logger,
                 log_level=loglevel,
+                process_step="collect_files",
             )
             (prsn_file,) = collect_output_files("prsn", self.workdir)
 
@@ -183,8 +195,9 @@ class GeneratePrsn(Process):
                 self,
                 response,
                 "Building final output",
-                process_step="build_output",
+                logger,
                 log_level=loglevel,
+                process_step="build_output",
             )
             response.outputs["output"].file = os.path.join(self.workdir, prsn_file)
 
@@ -192,7 +205,8 @@ class GeneratePrsn(Process):
             self,
             response,
             "Process Complete",
-            process_step="complete",
+            logger,
             log_level=loglevel,
+            process_step="complete",
         )
         return response

--- a/thunderbird/processes/wps_split_merged_climos.py
+++ b/thunderbird/processes/wps_split_merged_climos.py
@@ -12,6 +12,7 @@ from nchelpers import CFDataset
 from dp.split_merged_climos import split_merged_climos
 from wps_tools.utils import MAX_OCCURS, get_filepaths, build_meta_link, log_handler
 from wps_tools.io import log_level, meta4_output
+from thunderbird.utils import logger
 
 
 class SplitMergedClimos(Process):
@@ -53,7 +54,12 @@ class SplitMergedClimos(Process):
     def _handler(self, request, response):
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
-            self, response, "Starting Process", process_step="start", log_level=loglevel
+            self,
+            response,
+            "Starting Process",
+            logger,
+            log_level=loglevel,
+            process_step="start",
         )
 
         filepaths = get_filepaths(request.inputs["netcdf"])
@@ -61,8 +67,9 @@ class SplitMergedClimos(Process):
             self,
             response,
             f"Spliting climo files: {filepaths}",
-            process_step="process",
+            logger,
             log_level=loglevel,
+            process_step="process",
         )
         output_filepaths = []
         for path in filepaths:
@@ -79,8 +86,9 @@ class SplitMergedClimos(Process):
             self,
             response,
             "Building final output",
-            process_step="build_output",
+            logger,
             log_level=loglevel,
+            process_step="build_output",
         )
         response.outputs["output"].data = build_meta_link(
             varname="split_climo",
@@ -93,7 +101,8 @@ class SplitMergedClimos(Process):
             self,
             response,
             "Process Complete",
-            process_step="complete",
+            logger,
             log_level=loglevel,
+            process_step="complete",
         )
         return response

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -12,6 +12,7 @@ from dp.update_metadata import process_updates
 from nchelpers import CFDataset
 from wps_tools.utils import is_opendap_url, log_handler
 from wps_tools.io import nc_output, log_level
+from thunderbird.utils import logger
 
 # Library imports
 import shutil
@@ -94,7 +95,12 @@ class UpdateMetadata(Process):
     def _handler(self, request, response):
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
-            self, response, "Starting Process", process_step="start", log_level=loglevel
+            self,
+            response,
+            "Starting Process",
+            logger,
+            log_level=loglevel,
+            process_step="start",
         )
 
         filepath = self.copy_and_get_filepath(request)
@@ -112,8 +118,9 @@ class UpdateMetadata(Process):
                 self,
                 response,
                 f"Updating {filepath} metadata",
-                process_step="process",
+                logger,
                 log_level=loglevel,
+                process_step="process",
             )
             process_updates(dataset, updates_instruction)
 
@@ -121,8 +128,9 @@ class UpdateMetadata(Process):
             self,
             response,
             "Building final output",
-            process_step="build_output",
+            logger,
             log_level=loglevel,
+            process_step="build_output",
         )
         response.outputs["output"].file = filepath
 
@@ -130,7 +138,8 @@ class UpdateMetadata(Process):
             self,
             response,
             "Process Complete",
-            process_step="complete",
+            logger,
             log_level=loglevel,
+            process_step="complete",
         )
         return response

--- a/thunderbird/utils.py
+++ b/thunderbird/utils.py
@@ -2,6 +2,16 @@
 import logging
 import os
 
+logger = logging.getLogger("PYWPS")
+logger.setLevel(logging.NOTSET)
+
+formatter = logging.Formatter(
+    "%(asctime)s %(levelname)s: thunderbird: %(message)s", "%Y-%m-%d %H:%M:%S"
+)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
 
 def dry_run_info(filename, dry_run_method, **kwargs):
     """


### PR DESCRIPTION
This PR solves [issue 90](https://github.com/pacificclimate/thunderbird/issues/90), which is to update each process to use the `log_handler` function from `wps-tools 0.1.2`. In doing so, a logger object has been created with a unique formatter.