### PR TITLE
Makefile update

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,14 +17,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      env:
-        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
-        sudo apt-get update
-        sudo apt-get install cdo
-        pip install -U pip pytest
-        pip install -r requirements.txt
-        pip install -e .[dev]
+        make install-ci
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
       run: |

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ install-cdo:
 	@-bash -c "sudo apt-get update"
 	@-bash -c "sudo apt-get install cdo"
 
+.PHONY: install-ci
+install-ci: install-cdo
+	@echo "Installing ci requirements"
+	@-bash -c 'pip install -r requirements.txt'
+	@-bash -c 'pip install -e ".[dev]"'
+
 .PHONY: develop
 develop: install-cdo venv
 	@echo "Installing development requirements for tests and docs ..."

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 install: install-cdo venv
 	@echo "Installing application ..."
 	@-bash -c '${PIP} install -e .'
-	@echo "\nStart service with \`make start'"
+	@echo "\nStart service with \`thunderbird start'"
 
 .PHONY: install-cdo
 install-cdo:
@@ -62,24 +62,27 @@ develop: install-cdo venv
 	@echo "Installing development requirements for tests and docs ..."
 	@-bash -c '${PIP} install -e ".[dev]"'
 
-.PHONY: start
-start: venv
-	@echo "Starting application ..."
-	@-bash -c "${VENV}/bin/$(APP_NAME) start -d"
-
-.PHONY: stop
-stop: venv
-	@echo "Stopping application ..."
-	@-bash -c "${VENV}/bin/$(APP_NAME) stop"
-
-.PHONY: restart
-restart: venv stop start
-	@echo "Restarting application ..."
-
-.PHONY: status
-status: venv
-	@echo "Show status ..."
-	@-bash -c "${VENV}/bin/$(APP_NAME) status"
+# These commands have been disabled until further notice. Due to the issues with
+# cdo's signal handling, we cannot reliably start/stop using make.
+#
+# .PHONY: start
+# start: venv
+# 	@echo "Starting application ..."
+# 	@-bash -c "${VENV}/bin/$(APP_NAME) start -d"
+#
+# .PHONY: stop
+# stop: venv
+# 	@echo "Stopping application ..."
+# 	@-bash -c "${VENV}/bin/$(APP_NAME) stop"
+#
+# .PHONY: restart
+# restart: venv stop start
+# 	@echo "Restarting application ..."
+#
+# .PHONY: status
+# status: venv
+# 	@echo "Show status ..."
+# 	@-bash -c "${VENV}/bin/$(APP_NAME) status"
 
 .PHONY: clean
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts


### PR DESCRIPTION
# Changes
- update `makefile`
- use `make` in `ci` action

# Notes 
The `makefile` fell a bit out of date with our changes. This PR updates some existing commands and adds new ones. Running `make` will take care of a full installation, while running `make develop` will runs further installs for development. `thunderbird` can also be started, stopped and restarted using `make`. However, we should steer clear from using these commands until the signal issue in `cdo` is solved.

Resolves #93 