### PR TITLE
Suppress sql logging with config

### DIFF
--- a/pavics-component/wps.cfg.template
+++ b/pavics-component/wps.cfg.template
@@ -3,6 +3,7 @@ outputurl = https://${PAVICS_FQDN_PUBLIC}/wpsoutputs
 outputpath = /data/wpsoutputs
 
 [logging]
-level = DEBUG
+level = INFO
+db_echo = false
 
 ${EXTRA_PYWPS_CONFIG}

--- a/thunderbird/default.cfg
+++ b/thunderbird/default.cfg
@@ -18,3 +18,4 @@ parallelprocesses = 2
 level = INFO
 file = thunderbird.log
 format = [%(asctime)s] [%(levelname)s] line=%(lineno)s module=%(module)s %(message)s
+db_echo = false


### PR DESCRIPTION
Resolves #107.

```
[nrados@docker-dev03 birdhouse]$ docker logs thunderbird
[2020-09-29 19:23:44 +0000] [1] [INFO] Starting gunicorn 20.0.4
[2020-09-29 19:23:44 +0000] [1] [INFO] Listening at: http://0.0.0.0:5001 (1)
[2020-09-29 19:23:44 +0000] [1] [INFO] Using worker: sync
[2020-09-29 19:23:44 +0000] [8] [INFO] Booting worker with pid: 8
2020-09-29 19:23:58 INFO: thunderbird: Request: getcapabilities
2020-09-29 19:23:58 INFO: thunderbird: Request: getcapabilities
2020-09-29 19:24:02 INFO: thunderbird: Request: getcapabilities
2020-09-29 19:24:02 INFO: thunderbird: Request: getcapabilities
```