### PR TITLE
Increase maxrequestsize to 100 GB

### DIFF
--- a/pavics-component/wps.cfg.template
+++ b/pavics-component/wps.cfg.template
@@ -1,6 +1,7 @@
 [server]
 outputurl = https://${PAVICS_FQDN_PUBLIC}/wpsoutputs
 outputpath = /data/wpsoutputs
+maxrequestsize = 100gb
 
 [logging]
 level = INFO


### PR DESCRIPTION
Resolves #110 

The input file size limit can be configured as [maxrequestsize](https://pywps.readthedocs.io/en/latest/configuration.html#server) in `pywps` configuration file. The maximum limit to the input is now set to 100 GB based on the [largest files](https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/catalog/datasets/BCCAQv2/catalog.html) in the server