### PR TITLE
ComplexInput allows Thunderbird to access local updates yaml files

### DIFF
--- a/docs/source/notebooks/wps_update_metadata_demo.ipynb
+++ b/docs/source/notebooks/wps_update_metadata_demo.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# run update_metadata\n",
+    "# run update_metadata with yaml text and opendap netcdf inputs\n",
     "updates_text = '''\n",
     "global:\n",
     "    - institute_id:\n",
@@ -81,6 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# run update_metadata with yaml file and local netcdf inputs\n",
     "updates_file = resource_filename('tests', 'metadata-conversion/simple-conversion.yaml')\n",
     "local_netcdf = resource_filename('tests', 'data/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc')\n",
     "local_output = thunderbird.update_metadata(updates = updates_file, netcdf = local_netcdf)"

--- a/docs/source/notebooks/wps_update_metadata_demo.ipynb
+++ b/docs/source/notebooks/wps_update_metadata_demo.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,9 +42,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0mthunderbird\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mupdate_metadata\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mnetcdf\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mupdates_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mupdates_string\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Update file containing missing, invalid, or incorrectly named global or variable metadata attributes\n",
+       "\n",
+       "Parameters\n",
+       "----------\n",
+       "netcdf : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`application/x-ogc-dods`\n",
+       "    NetCDF file\n",
+       "updates_file : ComplexData:mimetype:`text/x-yaml`\n",
+       "    The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file\n",
+       "updates_string : string\n",
+       "    The string in yaml format that specifies what to do to the metadata it finds in the NetCDF file\n",
+       "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
+       "    Logging level\n",
+       "\n",
+       "Returns\n",
+       "-------\n",
+       "output : ComplexData:mimetype:`application/x-netcdf`\n",
+       "    Output Netcdf File\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/thunderbird/</home/sangwonl/Desktop/thunderbird/venv/lib/python3.7/site-packages/birdy/client/base.py-2>\n",
+       "\u001b[0;31mType:\u001b[0m      method\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "thunderbird.update_metadata?"
@@ -59,12 +95,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "# run update_metadata with yaml text and opendap netcdf inputs\n",
-    "updates_text = '''\n",
+    "updates_string = '''\n",
     "global:\n",
     "    - institute_id:\n",
     "    - institute_ID: PCIC\n",
@@ -72,19 +108,19 @@
     "    - Institution: <- institution\n",
     "'''\n",
     "opendap_netcdf = \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\"\n",
-    "opendap_output = thunderbird.update_metadata(updates = updates_text, netcdf = opendap_netcdf)"
+    "opendap_output = thunderbird.update_metadata(updates_string = updates_string, netcdf = opendap_netcdf)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "# run update_metadata with yaml file and local netcdf inputs\n",
     "updates_file = resource_filename('tests', 'metadata-conversion/simple-conversion.yaml')\n",
     "local_netcdf = resource_filename('tests', 'data/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc')\n",
-    "local_output = thunderbird.update_metadata(updates = updates_file, netcdf = local_netcdf)"
+    "local_output = thunderbird.update_metadata(updates_file = updates_file, netcdf = local_netcdf)"
    ]
   },
   {
@@ -96,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,11 +153,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def test_metadata(output_data):\n",
+    "def test_metadata(output):\n",
     "    with NamedTemporaryFile(suffix=\".nc\", prefix=\"tmp_copy\", dir=\"/tmp\", delete=True) as tmp_file:\n",
     "        output_data = Dataset(copy_http_content(output.get()[0], tmp_file))\n",
     "\n",
@@ -137,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/source/notebooks/wps_update_metadata_demo.ipynb
+++ b/docs/source/notebooks/wps_update_metadata_demo.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,37 +42,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mthunderbird\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mupdate_metadata\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnetcdf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mupdates\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m\n",
-       "Update file containing missing, invalid, or incorrectly named global or variable metadata attributes\n",
-       "\n",
-       "Parameters\n",
-       "----------\n",
-       "netcdf : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`application/x-ogc-dods`\n",
-       "    NetCDF file\n",
-       "updates : string\n",
-       "    The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file\n",
-       "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
-       "    Logging level\n",
-       "\n",
-       "Returns\n",
-       "-------\n",
-       "output : ComplexData:mimetype:`application/x-netcdf`\n",
-       "    Output Netcdf File\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/thunderbird/</home/sangwonl/Desktop/thunderbird/venv/lib/python3.7/site-packages/birdy/client/base.py-2>\n",
-       "\u001b[0;31mType:\u001b[0m      method\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "thunderbird.update_metadata?"
@@ -87,20 +59,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# run update_metadata\n",
-    "updates = '''\n",
+    "updates_text = '''\n",
     "global:\n",
     "    - institute_id:\n",
     "    - institute_ID: PCIC\n",
     "    - address: University House 1 \n",
     "    - Institution: <- institution\n",
     "'''\n",
-    "netcdf = \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\"\n",
-    "output = thunderbird.update_metadata(updates = updates, netcdf = netcdf)"
+    "opendap_netcdf = \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\"\n",
+    "opendap_output = thunderbird.update_metadata(updates = updates_text, netcdf = opendap_netcdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "updates_file = resource_filename('tests', 'metadata-conversion/simple-conversion.yaml')\n",
+    "local_netcdf = resource_filename('tests', 'data/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc')\n",
+    "local_output = thunderbird.update_metadata(updates = updates_file, netcdf = local_netcdf)"
    ]
   },
   {
@@ -112,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,39 +116,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "with NamedTemporaryFile(suffix=\".nc\", prefix=\"tmp_copy\", dir=\"/tmp\", delete=True) as tmp_file:\n",
-    "    output_data = Dataset(copy_http_content(output.get()[0], tmp_file))\n",
+    "def test_metadata(output_data):\n",
+    "    with NamedTemporaryFile(suffix=\".nc\", prefix=\"tmp_copy\", dir=\"/tmp\", delete=True) as tmp_file:\n",
+    "        output_data = Dataset(copy_http_content(output.get()[0], tmp_file))\n",
     "\n",
-    "# updated metadata\n",
-    "metadata = {\n",
-    "    \"institute_ID\": output_data.institute_ID,\n",
-    "    \"address\": output_data.address,\n",
-    "    \"Institution\": output_data.Institution,\n",
-    "}\n",
+    "    # updated metadata\n",
+    "    metadata = {\n",
+    "        \"institute_ID\": output_data.institute_ID,\n",
+    "        \"address\": output_data.address,\n",
+    "        \"Institution\": output_data.Institution,\n",
+    "    }\n",
     "\n",
-    "assert metadata == expected"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process failed, please check server error log'}\n"
-     ]
-    }
-   ],
-   "source": [
-    "updates = resource_filename('tests', 'metadata-conversion/simple-conversion.yaml')\n",
-    "output = thunderbird.update_metadata(updates = updates, netcdf = netcdf)"
+    "    assert metadata == expected"
    ]
   },
   {
@@ -173,7 +139,10 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "test_metadata(opendap_output)\n",
+    "test_metadata(local_output)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/source/notebooks/wps_update_metadata_demo.ipynb
+++ b/docs/source/notebooks/wps_update_metadata_demo.ipynb
@@ -19,6 +19,7 @@
     "warnings.filterwarnings(\"ignore\", category=DeprecationWarning) \n",
     "\n",
     "from birdy import WPSClient\n",
+    "from pkg_resources import resource_filename\n",
     "import os\n",
     "from wps_tools.utils import copy_http_content\n",
     "from netCDF4 import Dataset\n",
@@ -148,6 +149,31 @@
     "\n",
     "assert metadata == expected"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process failed, please check server error log'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "updates = resource_filename('tests', 'metadata-conversion/simple-conversion.yaml')\n",
+    "output = thunderbird.update_metadata(updates = updates, netcdf = netcdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_wps_update_metadata.py
+++ b/tests/test_wps_update_metadata.py
@@ -32,9 +32,9 @@ global:
 
 def build_params(netcdf, updates):
     if os.path.isfile(updates):
-        return ("netcdf=@xlink:href={0};" "updates_file={1};").format(netcdf, updates)
+        return f"netcdf=@xlink:href={netcdf};updates_file={updates};"
     else:
-        return ("netcdf=@xlink:href={0};" "updates_string={1};").format(netcdf, updates)
+        return f"netcdf=@xlink:href={netcdf};updates_string={updates};"
 
 
 @pytest.mark.online

--- a/tests/test_wps_update_metadata.py
+++ b/tests/test_wps_update_metadata.py
@@ -1,6 +1,6 @@
 import pytest
+import os
 from pkg_resources import resource_filename, resource_listdir
-
 
 from .testdata import TESTDATA
 from wps_tools.testing import run_wps_process, local_path, opendap_path
@@ -31,7 +31,10 @@ global:
 
 
 def build_params(netcdf, updates):
-    return ("netcdf=@xlink:href={0};" "updates={1};").format(netcdf, updates)
+    if os.path.isfile(updates):
+        return ("netcdf=@xlink:href={0};" "updates_file={1};").format(netcdf, updates)
+    else:
+        return ("netcdf=@xlink:href={0};" "updates_string={1};").format(netcdf, updates)
 
 
 @pytest.mark.online

--- a/thunderbird/default.cfg
+++ b/thunderbird/default.cfg
@@ -10,6 +10,7 @@ provider_url=https://thunderbird.readthedocs.org/en/latest/
 url = http://localhost:5001/wps
 outputurl = http://localhost:5001/outputs
 allowedinputpaths = /
+maxrequestsize = 200mb
 maxsingleinputsize = 200mb
 maxprocesses = 10
 parallelprocesses = 2

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -108,11 +108,11 @@ class UpdateMetadata(Process):
         holds the path to the origial file path.
         """
         if "updates_file" in request.inputs.keys():
-            try:
+            if vars(request.inputs["updates_file"][0])["_data"] != None:
                 updates = request.inputs["updates_file"][
                     0
                 ].data  # For running in localhost
-            except exceptions.NoApplicableCode:
+            else:
                 updates = request.inputs["updates_file"][
                     0
                 ].url  # For running in Docker containers

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -105,14 +105,10 @@ class UpdateMetadata(Process):
         )
 
         filepath = self.copy_and_get_filepath(request)
-        updates = request.inputs["updates"][0]
+        updates = request.inputs["updates"][0].data
 
-        # determines if the input `updates` is a file or a string
-        if os.path.isfile(updates.file):
-            with open(updates.file) as ud:
-                updates_instruction = yaml.safe_load(ud)
-        else:
-            updates_instruction = yaml.safe_load(updates)
+        # Converts the yaml (updates file) content into a dictionary
+        updates_instruction = yaml.safe_load(updates)
 
         with CFDataset(filepath, mode="r+") as dataset:
             log_handler(

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -45,7 +45,7 @@ class UpdateMetadata(Process):
                 abstract="The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file",
                 min_occurs=1,
                 max_occurs=1,
-                supported_formats=[Format('yaml')],
+                supported_formats=[Format("yaml")],
             ),
             log_level,
         ]
@@ -109,7 +109,7 @@ class UpdateMetadata(Process):
 
         # determines if the input `updates` is a file or a string
         if os.path.isfile(updates.file):
-            with open(updates) as ud:
+            with open(updates.file) as ud:
                 updates_instruction = yaml.safe_load(ud)
         else:
             updates_instruction = yaml.safe_load(updates)

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -39,7 +39,7 @@ class UpdateMetadata(Process):
                 abstract="The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file",
                 min_occurs=1,
                 max_occurs=1,
-                supported_formats=[Format(mime_type="text/plain", extension="yaml",)],
+                supported_formats=[Format(mime_type="text/x-yaml", extension="yaml",)],
             ),
             log_level,
         ]

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -104,10 +104,10 @@ class UpdateMetadata(Process):
         )
 
         filepath = self.copy_and_get_filepath(request)
-        updates = request.inputs["updates"][0].data
+        updates = request.inputs["updates"][0]
 
         # determines if the input `updates` is a file or a string
-        if os.path.isfile(updates):
+        if os.path.isfile(updates.url):
             with open(updates) as ud:
                 updates_instruction = yaml.safe_load(ud)
         else:

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -107,7 +107,7 @@ class UpdateMetadata(Process):
             # Input content is directly accessible using '.url' attribute when run in docker containers
             updates = request.inputs["updates"][0].url
 
-        # Determines 'updates' is a path or a string and converts the yaml (updates file) content into a dictionary
+        # Convert yaml content to a dictionary
         if os.path.isfile(updates):
             with open(updates) as ud:
                 updates_instruction = yaml.safe_load(ud)

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -34,12 +34,20 @@ class UpdateMetadata(Process):
                 supported_formats=[FORMATS.NETCDF, FORMATS.DODS],
             ),
             ComplexInput(
-                "updates",
+                "updates_file",
                 "Updates File(yaml)",
                 abstract="The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file",
-                min_occurs=1,
+                min_occurs=0,
                 max_occurs=1,
-                supported_formats=[Format(mime_type="text/x-yaml", extension="yaml",)],
+                supported_formats=[Format(mime_type="text/x-yaml", extension=".yaml",)],
+            ),
+            LiteralInput(
+                "updates_string",
+                "Updates String(yaml format)",
+                abstract="The string in yaml format that specifies what to do to the metadata it finds in the NetCDF file",
+                min_occurs=0,
+                max_occurs=1,
+                data_type="string",
             ),
             log_level,
         ]
@@ -87,6 +95,33 @@ class UpdateMetadata(Process):
         shutil.copyfile(original, copy)
         return copy
 
+    def updates_instruction_generator(self, request):
+        """
+        This function generates a dictionary containing the updates instruction information.
+        The dictionary will be constructed using the content of the input updates_file/updates_string.
+        It is desired that only one of the options is provided by the user, but if both are given, 
+        updates_file input will be used to generate whiile updates_string input will be neglected.
+
+        There are odd behaviours of the ComplexInput updates_file; the content of the yaml file is 
+        directly accessible using the .data attribute when run in localhost while it is accessible 
+        as '.url' attribute when run in docker containers. When running pytest, the .data attribute
+        holds the path to the origial file path.
+        """
+        if "updates_file" in request.inputs.keys():
+            try:
+                updates = request.inputs["updates_file"][0].data
+            except exceptions.NoApplicableCode:
+                updates = request.inputs["updates_file"][0].url
+        elif "updates_string" in request.inputs.keys():
+            updates = request.inputs["updates_string"][0].data
+
+        # Convert yaml content to a dictionary
+        if os.path.isfile(updates):  # For pythest
+            with open(updates) as ud:
+                return yaml.safe_load(ud)
+        else:
+            return yaml.safe_load(updates)
+
     def _handler(self, request, response):
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
@@ -98,22 +133,9 @@ class UpdateMetadata(Process):
             process_step="start",
         )
 
+        updates_instruction = self.updates_instruction_generator(request)
+
         filepath = self.copy_and_get_filepath(request)
-
-        try:
-            # Input content is directly accessible using '.data' attribute
-            updates = request.inputs["updates"][0].data
-        except exceptions.NoApplicableCode:
-            # Input content is directly accessible using '.url' attribute when run in docker containers
-            updates = request.inputs["updates"][0].url
-
-        # Convert yaml content to a dictionary
-        if os.path.isfile(updates):
-            with open(updates) as ud:
-                updates_instruction = yaml.safe_load(ud)
-        else:
-            updates_instruction = yaml.safe_load(updates)
-
         with CFDataset(filepath, mode="r+") as dataset:
             log_handler(
                 self,

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -100,7 +100,7 @@ class UpdateMetadata(Process):
         This function generates a dictionary containing the updates instruction information.
         The dictionary will be constructed using the content of the input updates_file/updates_string.
         It is desired that only one of the options is provided by the user, but if both are given, 
-        updates_file input will be used to generate whiile updates_string input will be neglected.
+        updates_file input will be used to generate while updates_string input will be neglected.
 
         There are odd behaviours of the ComplexInput updates_file; the content of the yaml file is 
         directly accessible using the .data attribute when run in localhost while it is accessible 

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -1,5 +1,6 @@
 # Processor imports
 from pywps import (
+    Format,
     Process,
     LiteralInput,
     ComplexInput,
@@ -44,7 +45,7 @@ class UpdateMetadata(Process):
                 abstract="The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file",
                 min_occurs=1,
                 max_occurs=1,
-                supported_formats=[FORMATS.TEXT],
+                supported_formats=[Format('yaml')],
             ),
             log_level,
         ]

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -39,7 +39,7 @@ class UpdateMetadata(Process):
                 abstract="The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file",
                 min_occurs=1,
                 max_occurs=1,
-                supported_formats=[Format("yaml")],
+                supported_formats=[Format(mime_type="text/plain", extension="yaml",)],
             ),
             log_level,
         ]

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -105,9 +105,10 @@ class UpdateMetadata(Process):
 
         filepath = self.copy_and_get_filepath(request)
         updates = request.inputs["updates"][0]
-
+        logger.critical(updates.file)
+        
         # determines if the input `updates` is a file or a string
-        if os.path.isfile(updates.url):
+        if os.path.isfile(updates.file):
             with open(updates) as ud:
                 updates_instruction = yaml.safe_load(ud)
         else:

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -1,6 +1,5 @@
 # Processor imports
 from pywps import (
-    Format,
     Process,
     LiteralInput,
     ComplexInput,
@@ -45,7 +44,7 @@ class UpdateMetadata(Process):
                 abstract="The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file",
                 min_occurs=1,
                 max_occurs=1,
-                supported_formats=[Format("yaml")],
+                supported_formats=[FORMATS.TEXT],
             ),
             log_level,
         ]
@@ -105,10 +104,13 @@ class UpdateMetadata(Process):
         )
 
         filepath = self.copy_and_get_filepath(request)
-        updates = request.inputs["updates"][0].data
+        updates = request.inputs["updates"][0]
 
         # Converts the yaml (updates file) content into a dictionary
-        updates_instruction = yaml.safe_load(updates)
+        if updates.data != None:
+            updates_instruction = yaml.safe_load(updates.data)
+        elif updates.url != None:
+            updates_instruction = yaml.safe_load(updates.url)
 
         with CFDataset(filepath, mode="r+") as dataset:
             log_handler(

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -38,13 +38,13 @@ class UpdateMetadata(Process):
                 max_occurs=1,
                 supported_formats=[FORMATS.NETCDF, FORMATS.DODS],
             ),
-            LiteralInput(
+            ComplexInput(
                 "updates",
                 "Updates File(yaml)",
                 abstract="The filepath of an updates file that specifies what to do to the metadata it finds in the NetCDF file",
                 min_occurs=1,
                 max_occurs=1,
-                data_type="string",
+                supported_formats=[FORMATS.TEXT],
             ),
             log_level,
         ]

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -105,7 +105,6 @@ class UpdateMetadata(Process):
 
         filepath = self.copy_and_get_filepath(request)
         updates = request.inputs["updates"][0]
-        logger.critical(updates.file)
         
         # determines if the input `updates` is a file or a string
         if os.path.isfile(updates.file):

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -104,13 +104,20 @@ class UpdateMetadata(Process):
         )
 
         filepath = self.copy_and_get_filepath(request)
-        updates = request.inputs["updates"][0]
 
-        # Converts the yaml (updates file) content into a dictionary
-        if updates.data != None:
-            updates_instruction = yaml.safe_load(updates.data)
-        elif updates.url != None:
-            updates_instruction = yaml.safe_load(updates.url)
+        # The input 'updates' is stored as a 'data' attribute when the process is run on localhost
+        if request.inputs["updates"][0].data != None:
+            updates = request.inputs["updates"][0].data
+        # The input 'updates' is stored as an 'url' attribute when the process is run in a docker container
+        elif request.inputs["updates"][0].url != None:
+            updates = request.inputs["updates"][0].url
+
+        # Determines 'updates' is a path or a string and converts the yaml (updates file) content into a dictionary
+        if os.path.isfile(updates):
+            with open(updates) as ud:
+                updates_instruction = yaml.safe_load(ud)
+        else:
+            updates_instruction = yaml.safe_load(updates)
 
         with CFDataset(filepath, mode="r+") as dataset:
             log_handler(

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -109,14 +109,18 @@ class UpdateMetadata(Process):
         """
         if "updates_file" in request.inputs.keys():
             try:
-                updates = request.inputs["updates_file"][0].data
+                updates = request.inputs["updates_file"][
+                    0
+                ].data  # For running in localhost
             except exceptions.NoApplicableCode:
-                updates = request.inputs["updates_file"][0].url
+                updates = request.inputs["updates_file"][
+                    0
+                ].url  # For running in Docker containers
         elif "updates_string" in request.inputs.keys():
             updates = request.inputs["updates_string"][0].data
 
         # Convert yaml content to a dictionary
-        if os.path.isfile(updates):  # For pythest
+        if os.path.isfile(updates):  # For running pytest
             with open(updates) as ud:
                 return yaml.safe_load(ud)
         else:

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -105,7 +105,7 @@ class UpdateMetadata(Process):
 
         filepath = self.copy_and_get_filepath(request)
         updates = request.inputs["updates"][0]
-        
+
         # determines if the input `updates` is a file or a string
         if os.path.isfile(updates.file):
             with open(updates) as ud:

--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -105,12 +105,12 @@ class UpdateMetadata(Process):
 
         filepath = self.copy_and_get_filepath(request)
 
-        # The input 'updates' is stored as a 'data' attribute when the process is run on localhost
-        if request.inputs["updates"][0].data != None:
-            updates = request.inputs["updates"][0].data
         # The input 'updates' is stored as an 'url' attribute when the process is run in a docker container
-        elif request.inputs["updates"][0].url != None:
+        if request.inputs["updates"][0].url != None:
             updates = request.inputs["updates"][0].url
+        # The input 'updates' is stored as a 'data' attribute when the process is run on localhost
+        elif request.inputs["updates"][0].data != None:
+            updates = request.inputs["updates"][0].data
 
         # Determines 'updates' is a path or a string and converts the yaml (updates file) content into a dictionary
         if os.path.isfile(updates):


### PR DESCRIPTION
# Changes
- Add a ComplexInput `updates_file` in `wps_update_metadata`.
- Change the name of the LiteralInput `updates` to 'updates_string` in `wps_update_metadata`.
- Updated `test_wps_update_metadata` and `wps_update_metadata_demo` to test the changes.
- Increased `maxrequestsize` of Docker containers for development purpose.

Resolves #115 

# Notes
The issue was caused due to the inability of uploading `yaml` files to Docker containers since the input was passed as a [literal input](https://pywps.readthedocs.io/en/latest/process.html#literaldata). The input is now replaced to a complex input with `supported_formats=[`[Format](https://pywps.readthedocs.io/en/latest/_modules/pywps/inout/formats.html#Format)`(mime_type="text/x-yaml", extension=".yaml",)]` since `yaml` is not in predefined [pywps.FORMATS](https://pywps.readthedocs.io/en/latest/api.html#pywps.inout.formats.FORMATS). 

There are odd behaviours of the ComplexInput `updates_file`; the content of the `yaml` file is directly accessible using the `.data` attribute when run in localhost while it is accessible as `.url` attribute when run in docker containers. When running `pytest`, the `.data` attribute holds the path to the original file path.

When reviewing the PR, change the URL to `http://docker-dev03.pcic.uvic.ca:30123/wps` in jupyter lab, which hosts `thunderbird_test` container. Note that the 3rd and the last cells will not work in the thunderbird_test container.
