### PR TITLE
Use _file attribute when available

### DIFF
--- a/thunderbird/processes/wps_update_metadata.py
+++ b/thunderbird/processes/wps_update_metadata.py
@@ -108,7 +108,11 @@ class UpdateMetadata(Process):
         holds the path to the origial file path.
         """
         if "updates_file" in request.inputs.keys():
-            if vars(request.inputs["updates_file"][0])["_data"] != None:
+            if vars(request.inputs["updates_file"][0])["_file"] != None:
+                updates = request.inputs["updates_file"][
+                    0
+                ].file  # For running in localhost
+            elif vars(request.inputs["updates_file"][0])["_data"] != None:
                 updates = request.inputs["updates_file"][
                     0
                 ].data  # For running in localhost


### PR DESCRIPTION
resolves #123 

`.file` IOHandler is the primary use case for accessing `input.yaml` file if available. The cause of malfunctioning in uploading the local `updates_file` to Docker containers has not been identified yet.