### PR TITLE
Custom demo ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,18 @@ APP_NAME := thunderbird
 VENV?=/tmp/thunderbird-venv
 PYTHON=${VENV}/bin/python3
 PIP=${VENV}/bin/pip
+PIP_INDEX_URL=https://pypi.pacificclimate.org/simple
 
-WPS_URL = http://localhost:5001
-
-export PIP_INDEX_URL=https://pypi.pacificclimate.org/simple
+# Notebook targets
+LOCAL_URL = http://localhost:5001
+DEV_PORT ?= $(shell bash -c 'read -ep "Target port: " port; echo $$port')
 
 # Used in target refresh-notebooks to make it looks like the notebooks have
 # been refreshed from the production server below instead of from the local dev
 # instance so the notebooks can also be used as tutorial notebooks.
 OUTPUT_URL = https://docker-dev03.pcic.uvic.ca/wpsoutputs
-
 SANITIZE_FILE := https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/raw/master/notebooks/output-sanitize.cfg
+
 
 .PHONY: all
 all: develop test clean-test test-notebooks-online
@@ -144,13 +145,19 @@ notebook-sanitizer:
 .PHONY: test-notebooks
 test-notebooks: notebook-sanitizer
 	@echo "Running notebook-based tests"
-	@bash -c "source $(VENV)/bin/activate && env WPS_URL=$(WPS_URL) pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
+	@bash -c "source $(VENV)/bin/activate && env LOCAL_URL=$(LOCAL_URL) pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
 
 
 .PHONY: test-notebooks-online
 test-notebooks-online: notebook-sanitizer
 	@echo "Running notebook-based tests against online instance of thunderbird"
 	@bash -c "source $(VENV)/bin/activate && pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
+
+.PHONY: test-notebooks-custom
+test-notebooks-custom: notebook-sanitizer
+	@echo "Running notebook-based tests against custom docker instance of thunderbird"
+	@bash -c "source $(VENV)/bin/activate && env DEV_URL=http://docker-dev03.pcic.uvic.ca:$(DEV_PORT)/wps pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
+
 
 .PHONY: lint
 lint: venv

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ APP_NAME := thunderbird
 VENV?=/tmp/thunderbird-venv
 PYTHON=${VENV}/bin/python3
 PIP=${VENV}/bin/pip
-PIP_INDEX_URL=https://pypi.pacificclimate.org/simple
+export PIP_INDEX_URL=https://pypi.pacificclimate.org/simple
 
 # Notebook targets
 LOCAL_URL = http://localhost:5001

--- a/docs/source/notebooks/wps_decompose_flow_vectors_demo.ipynb
+++ b/docs/source/notebooks/wps_decompose_flow_vectors_demo.ipynb
@@ -20,12 +20,30 @@
     "from wps_tools.utils import copy_http_content\n",
     "from netCDF4 import Dataset\n",
     "from tempfile import NamedTemporaryFile\n",
+    "from thunderbird.utils import get_url\n",
     "\n",
     "# Ensure we are in the working directory with access to the data\n",
     "while os.path.basename(os.getcwd()) != \"thunderbird\":\n",
-    "    os.chdir('../')\n",
-    "\n",
-    "url = 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps'\n",
+    "    os.chdir('../')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "url = get_url()\n",
+    "print(f\"Using thunderbird on {url}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "thunderbird = WPSClient(url)"
    ]
   },

--- a/docs/source/notebooks/wps_generate_climos_demo.ipynb
+++ b/docs/source/notebooks/wps_generate_climos_demo.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,17 +27,35 @@
     "from netCDF4 import Dataset\n",
     "from tempfile import NamedTemporaryFile\n",
     "from bs4 import BeautifulSoup\n",
-    "import re"
+    "import re\n",
+    "from thunderbird.utils import get_url"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using thunderbird on https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "url = get_url()\n",
+    "print(f\"Using thunderbird on {url}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
-    "docker_url = 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps'\n",
-    "url = os.environ.get('WPS_URL', docker_url)\n",
     "thunderbird = WPSClient(url)"
    ]
   },

--- a/docs/source/notebooks/wps_generate_prsn_demo.ipynb
+++ b/docs/source/notebooks/wps_generate_prsn_demo.ipynb
@@ -21,10 +21,26 @@
     "from wps_tools.utils import copy_http_content\n",
     "from netCDF4 import Dataset\n",
     "from tempfile import NamedTemporaryFile\n",
-    "\n",
-    "\n",
-    "docker_url = 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps'\n",
-    "url = os.environ.get('WPS_URL', docker_url)\n",
+    "from thunderbird.utils import get_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "url = get_url()\n",
+    "print(f\"Using thunderbird on {url}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "thunderbird = WPSClient(url)"
    ]
   },

--- a/docs/source/notebooks/wps_split_merged_climos_demo.ipynb
+++ b/docs/source/notebooks/wps_split_merged_climos_demo.ipynb
@@ -20,14 +20,30 @@
     "import requests\n",
     "import os\n",
     "from bs4 import BeautifulSoup\n",
-    "\n",
+    "from thunderbird.utils import get_url\n",
     "\n",
     "# Ensure we are in the working directory with access to the data\n",
     "while os.path.basename(os.getcwd()) != \"thunderbird\":\n",
-    "    os.chdir('../')\n",
-    "\n",
-    "docker_url = 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps'\n",
-    "url = os.environ.get('WPS_URL', docker_url)\n",
+    "    os.chdir('../')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "url = get_url()\n",
+    "print(f\"Using thunderbird on {url}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "thunderbird = WPSClient(url)"
    ]
   },

--- a/docs/source/notebooks/wps_update_metadata_demo.ipynb
+++ b/docs/source/notebooks/wps_update_metadata_demo.ipynb
@@ -24,13 +24,30 @@
     "from wps_tools.utils import copy_http_content\n",
     "from netCDF4 import Dataset\n",
     "from tempfile import NamedTemporaryFile\n",
+    "from thunderbird.utils import get_url\n",
     "\n",
     "# Ensure we are in the working directory with access to the data\n",
     "while os.path.basename(os.getcwd()) != \"thunderbird\":\n",
-    "    os.chdir('../')\n",
-    "\n",
-    "docker_url = 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps'\n",
-    "url = os.environ.get('WPS_URL', docker_url)\n",
+    "    os.chdir('../')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "url = get_url()\n",
+    "print(f\"Using thunderbird on {url}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "thunderbird = WPSClient(url)"
    ]
   },

--- a/thunderbird/utils.py
+++ b/thunderbird/utils.py
@@ -41,13 +41,13 @@ def dry_output_filename(outdir, filename):
 
 
 def get_url():
-    '''Determine which url to target for notebooks
+    """Determine which url to target for notebooks
 
     "DEV" and "LOCAL" urls may be targeted by the Makefile testing procedures.
     If neither of those environment variables are set, the default docker url will be used.
-    '''
-    for url in [os.getenv('DEV_URL'), os.getenv('LOCAL_URL')]:
+    """
+    for url in [os.getenv("DEV_URL"), os.getenv("LOCAL_URL")]:
         if url:
             return url
 
-    return 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps'
+    return "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps"

--- a/thunderbird/utils.py
+++ b/thunderbird/utils.py
@@ -38,3 +38,16 @@ def dry_output_filename(outdir, filename):
         )
     else:
         return os.path.join(outdir, filename)
+
+
+def get_url():
+    '''Determine which url to target for notebooks
+
+    "DEV" and "LOCAL" urls may be targeted by the Makefile testing procedures.
+    If neither of those environment variables are set, the default docker url will be used.
+    '''
+    for url in [os.getenv('DEV_URL'), os.getenv('LOCAL_URL')]:
+        if url:
+            return url
+
+    return 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thunderbird/wps'


### PR DESCRIPTION
The goal was to create a way for us to test against dev versions of birds without having to manually change the notebooks. A command has been added to the `Makefile` that injects a user prompted input into the notebooks. The prompt is for the port portion of the `http://docker-dev03.pcic.uvic.ca:[port]/wps` url. Right now I have a dev instance of `thunderbird` running on `30666`, you can use that for testing this command. 

I added a function in the `utils` module that handles the logic for choosing the port. I plan to move this into `wps-tools` before bringing this change to other birds.

Resolves #122.