### PR TITLE
Errors with pytest/ test-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SANITIZE_FILE := https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/raw/mas
 
 
 .PHONY: all
-all: develop test clean-test test-notebooks-prod
+all: develop test-all clean-test test-notebooks-prod
 
 .PHONY: help
 help:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ psutil==5.7.0
 pywps==4.2.6
 xarray==0.15.1
 nchelpers==5.5.7
-wps-tools==0.2.0
+wps-tools==0.3.1

--- a/tests/test_wps_decompose_flow_vectors.py
+++ b/tests/test_wps_decompose_flow_vectors.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from .testdata import TESTDATA
-from wps_tools.testing import run_wps_process, local_path, opendap_path
+from wps_tools.testing import run_wps_process, local_path, url_path
 from thunderbird.processes.wps_decompose_flow_vectors import DecomposeFlowVectors
 
 
@@ -12,7 +12,7 @@ import os
 
 # limiting test_data to "sample_flow_parameters.nc"
 flow_vectors_opendap = [
-    opendap_path(opendap)
+    url_path(opendap, "opendap")
     for opendap in TESTDATA["test_opendaps"]
     if opendap.endswith("sample_flow_parameters.nc")
 ]

--- a/tests/test_wps_generate_climos.py
+++ b/tests/test_wps_generate_climos.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from .testdata import TESTDATA
-from wps_tools.testing import run_wps_process, local_path, opendap_path
+from wps_tools.testing import run_wps_process, local_path, url_path
 from thunderbird.processes.wps_generate_climos import GenerateClimos
 
 # limiting test_data to non-climo tiny datasets
@@ -14,7 +14,7 @@ local_test_data = [
 # NetCDFs with flow_vectors not adequate for generate_climos
 # refer to https://github.com/pacificclimate/climate-explorer-data-prep#generate_climos-generate-climatological-means
 opendap_data = [
-    opendap_path(opendap)
+    url_path(opendap, "opendap")
     for opendap in TESTDATA["test_opendaps"]
     if not (
         opendap.endswith("_climos.nc")

--- a/tests/test_wps_generate_prsn.py
+++ b/tests/test_wps_generate_prsn.py
@@ -3,7 +3,7 @@ import re
 
 
 from .testdata import TESTDATA
-from wps_tools.testing import run_wps_process, local_path, opendap_path
+from wps_tools.testing import run_wps_process, local_path, url_path
 from thunderbird.processes.wps_generate_prsn import GeneratePrsn
 
 local_nc_inputs = {
@@ -19,7 +19,7 @@ local_tiny_nc_inputs = {
 }
 
 opendap_inputs = {
-    opendap.split("_")[0]: opendap_path(opendap)
+    opendap.split("_")[0]: url_path(opendap, "opendap")
     for opendap in TESTDATA["test_opendaps"]
     if opendap.startswith("pr_")
     or opendap.startswith("tasmin_")

--- a/tests/test_wps_split_merged_climos.py
+++ b/tests/test_wps_split_merged_climos.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from .testdata import TESTDATA
-from wps_tools.testing import run_wps_process, local_path, opendap_path
+from wps_tools.testing import run_wps_process, local_path, url_path
 from thunderbird.processes.wps_split_merged_climos import SplitMergedClimos
 
 # limiting test_data to climo files
@@ -10,7 +10,7 @@ climo_local_files = [
     local_path(nc) for nc in TESTDATA["test_local_nc"] if nc.endswith("_climos.nc")
 ]
 climo_opendaps = [
-    opendap_path(opendap)
+    url_path(opendap, "opendap")
     for opendap in TESTDATA["test_opendaps"]
     if opendap.endswith("_climos.nc")
 ]

--- a/tests/test_wps_update_metadata.py
+++ b/tests/test_wps_update_metadata.py
@@ -3,7 +3,7 @@ import os
 from pkg_resources import resource_filename, resource_listdir
 
 from .testdata import TESTDATA
-from wps_tools.testing import run_wps_process, local_path, opendap_path
+from wps_tools.testing import run_wps_process, local_path, url_path
 from thunderbird.processes.wps_update_metadata import UpdateMetadata
 
 # limiting the test data to tiny_datasets
@@ -11,7 +11,7 @@ local_data = [
     local_path(nc) for nc in TESTDATA["test_local_nc"] if nc.startswith("tiny_")
 ]
 opendap_data = [
-    opendap_path(opendap)
+    url_path(opendap, "opendap")
     for opendap in TESTDATA["test_opendaps"]
     if opendap.startswith("tiny_")
 ]


### PR DESCRIPTION
### Pytest
`opendap_path` from `wps-tools` was replaced by the updated `url_path` with accurate storage paths for test data. 

### Makefile
`test` in `all` was replaced with `test-all` so that all pytests are covered

Run `pytest tests` or `make` or `make test-all` to test changes

Resolves #135 