### PR TITLE
Get asobj

### DIFF
--- a/notebooks/wps_decompose_flow_vectors_demo.ipynb
+++ b/notebooks/wps_decompose_flow_vectors_demo.ipynb
@@ -19,6 +19,7 @@
     "import os\n",
     "from wps_tools.testing import get_target_url\n",
     "from netCDF4 import Dataset\n",
+    "from xarray import open_dataset\n",
     "from tempfile import NamedTemporaryFile\n",
     "from wps_tools.output_handling import nc_to_dataset, auto_construct_outputs\n",
     "\n",
@@ -124,49 +125,9 @@
     "flow_vectors_file = \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/sample_flow_parameters.nc\"\n",
     "variable = \"Flow_Direction\"\n",
     "dest_file = \"output.nc\"\n",
-    "output = thunderbird.decompose_flow_vectors(netcdf=flow_vectors_file, variable=variable, dest_file=dest_file)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output with nc_to_dataset() or auto_construct_outputs() from wps_tools.output_handling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<class 'netCDF4._netCDF4.Dataset'>\n",
-       " root group (NETCDF4 data model, file format HDF5):\n",
-       "     GDAL_AREA_OR_POINT: Area\n",
-       "     Conventions: CF-1.5\n",
-       "     GDAL: GDAL 2.1.0, released 2016/04/25\n",
-       "     history: Thu Jan  7 12:06:21 2021 decompose_flow_vectors https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/sample_flow_parameters.nc /tmp/pywps_process_gn_9bjhm/output.nc Flow_Direction\n",
-       " Wed Sep 27 12:33:37 2017: ncatted -a long_name,Basin_ID,o,c,Basin ID -a long_name,diffusion,o,c,Diffusivity -a units,diffusion,a,c,1/m -a long_name,Flow_Direction,o,c,Flow Direction -a units,Flow_Direction,a,c,1 -a long_name,Flow_Distance,o,c,Flow Distance -a units,Flow_Distance,a,c,m -a long_name,velocity,o,c,Flow Velocity -a units,velocity,a,c,m/s pcic.pnw.rvic.input_20170927.nc\n",
-       " Wed Sep 27 11:08:09 2017: ncrename -v Band1,diffusion -v Band2,Flow_Distance -v Band3,Basin_ID -v Band4,velocity -v Band5,Flow_Direction rout-param_pnw_0625dd_v7.nc pcic.pnw.rvic.input_20170927.nc\n",
-       " Wed Sep 27 10:57:40 2017: GDAL CreateCopy( rout-param_pnw_0625dd_v7.nc, ... )\n",
-       "     NCO: \"4.6.0\"\n",
-       "     DODS.strlen: 0\n",
-       "     dimensions(sizes): lat(187), lon(239)\n",
-       "     variables(dimensions): float64 lat(lat), float64 lon(lon), float64 eastward_Flow_Direction(lat, lon), float64 northward_Flow_Direction(lat, lon)\n",
-       "     groups: ]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "output_data = nc_to_dataset(output.get()[0])\n",
-    "auto_construct_outputs(output.get())"
+    "output = thunderbird.decompose_flow_vectors(netcdf=flow_vectors_file, variable=variable, dest_file=dest_file)\n",
+    "# Use asobj=True to access the output file content as a Dataset\n",
+    "output_data = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -178,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +147,6 @@
     "    direction\n",
     "    for subarray in Dataset(flow_vectors_file).variables[\"Flow_Direction\"]\n",
     "    for direction in subarray\n",
-    "    if direction != \"masked\"\n",
     "]\n",
     "output_eastward =  [\n",
     "    x_magnitude \n",

--- a/notebooks/wps_generate_climos_demo.ipynb
+++ b/notebooks/wps_generate_climos_demo.ipynb
@@ -136,18 +136,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'http://localhost:5000/outputs/ab602d86-7ace-11eb-82d4-85fba3d3ed5b/input.meta4'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Set up variables for thunderbird.generate_climos\n",
     "seasonal_opendap = 'https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc'\n",
@@ -164,8 +153,7 @@
     "    climo=climo, \n",
     "    resolutions=resolutions, \n",
     "    dry_run=dry_run\n",
-    ")\n",
-    "dry_output.get()[0]"
+    ")"
    ]
   },
   {
@@ -205,7 +193,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['http://localhost:5000/outputs/ab602d87-7ace-11eb-82d4-85fba3d3ed5b/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt']\n",
+      "['http://localhost:5000/outputs/18ea7027-7ae5-11eb-82d4-85fba3d3ed5b/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt']\n",
       "Dry Run\n",
       "generate_climos:\n",
       "INFO:dp.generate_climos:Processing: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc\n",

--- a/notebooks/wps_generate_climos_demo.ipynb
+++ b/notebooks/wps_generate_climos_demo.ipynb
@@ -110,7 +110,7 @@
        "    Metalink object between output files\n",
        "dry_output : ComplexData:mimetype:`application/metalink+xml; version=4.0`\n",
        "    Metalink object between dry output files\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/code/birds/thunderbird/docs/source/notebooks/</tmp/thunderbird-venv/lib/python3.8/site-packages/birdy/client/base.py-0>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/code/birds/thunderbird/notebooks/</tmp/thunderbird-venv/lib/python3.8/site-packages/birdy/client/base.py-0>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -140,7 +140,7 @@
     {
      "data": {
       "text/plain": [
-       "'http://localhost:5000/outputs/8b3dcce2-545a-11eb-9bea-9bfa3f22d465/input.meta4'"
+       "'http://localhost:5000/outputs/ab602d86-7ace-11eb-82d4-85fba3d3ed5b/input.meta4'"
       ]
      },
      "execution_count": 5,
@@ -205,7 +205,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['http://localhost:5000/outputs/8b3dcce3-545a-11eb-9bea-9bfa3f22d465/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt']\n",
+      "['http://localhost:5000/outputs/ab602d87-7ace-11eb-82d4-85fba3d3ed5b/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100_dry.txt']\n",
       "Dry Run\n",
       "generate_climos:\n",
       "INFO:dp.generate_climos:Processing: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/fdd_seasonal_CanESM2_rcp85_r1i1p1_1951-2100.nc\n",

--- a/notebooks/wps_generate_prsn_demo.ipynb
+++ b/notebooks/wps_generate_prsn_demo.ipynb
@@ -1,8 +1,10 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 1,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# wps_generate_prsn\n",
     "\n",
@@ -11,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -46,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -104,7 +106,7 @@
        "    Output Netcdf File\n",
        "dry_output : ComplexData:mimetype:`text/plain`\n",
        "    File information\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/code/birds/thunderbird/docs/source/notebooks/</tmp/thunderbird-venv/lib/python3.8/site-packages/birdy/client/base.py-1>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/code/birds/thunderbird/notebooks/</tmp/thunderbird-venv/lib/python3.8/site-packages/birdy/client/base.py-1>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -126,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,18 +137,8 @@
     "tasmin_file_opendap = \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/tasmin_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\"\n",
     "tasmax_file_opendap = \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/tasmax_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\"\n",
     "\n",
-    "dry_output = thunderbird.generate_prsn(pr_file_opendap, tasmin_file_opendap, tasmax_file_opendap, chunk_size=50, dry_run=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "req = requests.get(dry_output.get()[0])\n",
-    "dependent_varnames = [line.split(\":\")[-1].strip(\" ['']\") for line in req.content.decode('utf-8').split(\"\\n\") if \"dependent_varnames\" in line]\n",
-    "assert dependent_varnames == ['pr', 'tasmin', 'tasmax']"
+    "dry_output = thunderbird.generate_prsn(pr_file_opendap, tasmin_file_opendap, tasmax_file_opendap, chunk_size=50, dry_run=True)\n",
+    "dry_output_data = dry_output.get(asobj=True)[0]"
    ]
   },
   {
@@ -155,94 +147,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Normal run\n",
-    "output = thunderbird.generate_prsn(pr_file_opendap, tasmin_file_opendap, tasmax_file_opendap, chunk_size=50, dry_run=False, output_file=\"prsn_test_mixed.nc\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output with **auto_construct_outputs()** or **txt_to_string()** and **nc_to_dataset** from wps_tools.output_handling"
+    "dependent_varnames = [line.split(\":\")[-1].strip(\" ['']\") for line in dry_output_data.split(\"\\n\") if \"dependent_varnames\" in line]\n",
+    "assert dependent_varnames == ['pr', 'tasmin', 'tasmax']"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[str, netCDF4._netCDF4.Dataset]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "outputs = auto_construct_outputs(dry_output.get() + output.get())\n",
-    "[type(output) for output in outputs]"
+    "# Normal run\n",
+    "output = thunderbird.generate_prsn(pr_file_opendap, tasmin_file_opendap, tasmax_file_opendap, chunk_size=50, dry_run=False, output_file=\"prsn_test_mixed.nc\")\n",
+    "# Use asobj=True to access the output file content as a Dataset\n",
+    "output_data = output.get(asobj=True)[0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dry Run\n",
-      "generate_prsn:Dry Run\n",
-      "INFO:dp.generate_prsn:\n",
-      "INFO:dp.generate_prsn:File: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/pr_day_BCCAQv2+ANUSPLIN300_NorESM1-M_historical+rcp26_r1i1p1_19500101-19500107.nc\n",
-      "INFO:dp.generate_prsn:project: CMIP5\n",
-      "INFO:dp.generate_prsn:model: NorESM1-M\n",
-      "INFO:dp.generate_prsn:institute: PCIC\n",
-      "INFO:dp.generate_prsn:experiment: historical,rcp26\n",
-      "INFO:dp.generate_prsn:ensemble_member: r1i1p1\n",
-      "INFO:dp.generate_prsn:dependent_varnames: ['pr']\n",
-      "INFO:dp.generate_prsn:\n",
-      "INFO:dp.generate_prsn:File: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/tasmin_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\n",
-      "INFO:dp.generate_prsn:project: CMIP5\n",
-      "INFO:dp.generate_prsn:model: NorESM1-M\n",
-      "INFO:dp.generate_prsn:institute: PCIC\n",
-      "INFO:dp.generate_prsn:experiment: historical,rcp26\n",
-      "INFO:dp.generate_prsn:ensemble_member: r1i1p1\n",
-      "INFO:dp.generate_prsn:dependent_varnames: ['tasmin']\n",
-      "INFO:dp.generate_prsn:\n",
-      "INFO:dp.generate_prsn:File: https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/tasmax_day_BCCAQv2%2BANUSPLIN300_NorESM1-M_historical%2Brcp26_r1i1p1_19500101-19500107.nc\n",
-      "INFO:dp.generate_prsn:project: CMIP5\n",
-      "INFO:dp.generate_prsn:model: NorESM1-M\n",
-      "INFO:dp.generate_prsn:institute: PCIC\n",
-      "INFO:dp.generate_prsn:experiment: historical,rcp26\n",
-      "INFO:dp.generate_prsn:ensemble_member: r1i1p1\n",
-      "INFO:dp.generate_prsn:dependent_varnames: ['tasmax']\n",
-      "\n",
-      "http://localhost:5000/outputs/ad971abc-5466-11eb-9bea-9bfa3f22d465/prsn_test_mixed.nc\n"
-     ]
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "output_data = output.get()[0]\n",
-    "nc_content = nc_to_dataset(output_data)\n",
-    "print(txt_to_string(dry_output.get()[0]))\n",
-    "print(output_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
    "outputs": [],
    "source": [
-    "assert 'prsn' in nc_content.variables.keys()"
+    "assert 'prsn' in output_data.variables.keys()"
    ]
   }
  ],

--- a/notebooks/wps_update_metadata_demo.ipynb
+++ b/notebooks/wps_update_metadata_demo.ipynb
@@ -134,7 +134,8 @@
     "    - Institution: <- institution\n",
     "'''\n",
     "opendap_netcdf = \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/projects/comp_support/daccs/test-data/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\"\n",
-    "opendap_output = thunderbird.update_metadata(updates_string = updates_string, netcdf = opendap_netcdf)"
+    "opendap_output = thunderbird.update_metadata(updates_string = updates_string, netcdf = opendap_netcdf)\n",
+    "opendap_output_data = opendap_output.get(asobj=True)[0]"
    ]
   },
   {
@@ -146,86 +147,8 @@
     "# run update_metadata with yaml file and local netcdf inputs\n",
     "updates_file = resource_filename('tests', 'metadata-conversion/simple-conversion.yaml')\n",
     "local_netcdf = resource_filename('tests', 'data/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc')\n",
-    "local_output = thunderbird.update_metadata(updates_file = updates_file, netcdf = local_netcdf)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output data with **nc_to_dataset()** or **auto_construct_outputs()** from wps_tools.output_handling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<class 'netCDF4._netCDF4.Dataset'>\n",
-       " root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "     Conventions: CF-1.4\n",
-       "     version: 1\n",
-       "     frequency: day\n",
-       "     product: output\n",
-       "     modeling_realm: atmos\n",
-       "     realization: 1\n",
-       "     references: Maurer, E.P., Hidalgo, H.G., Das, T., Dettinger, M.D., and Cayan, D.R., 2010.\n",
-       " The utility of daily large-scale climate data in the assessment of climate\n",
-       " change impacts on daily streamflow in California. Hydrology and Earth System\n",
-       " Sciences, 14: 1125-1138.\n",
-       "     comment: Quantile mapping extrapolation based on delta-method; tol=0.001\n",
-       "     contact: Alex Cannon (acannon@uvic.ca)\n",
-       "     driving_institution: Canadian Centre for Climate Modelling and Analysis\n",
-       "     driving_institute_id: CCCma\n",
-       "     driving_experiment: CanESM2, historical+rcp85, r1i1p1\n",
-       "     driving_model_id: CanESM2\n",
-       "     driving_model_ensemble_member: r1i1p1\n",
-       "     driving_experiment_name: historical, RCP8.5\n",
-       "     target_institution: Canadian Forest Service, Natural Resources Canada\n",
-       "     target_institute_id: CFS-NRCan\n",
-       "     target_dataset: ANUSPLIN interpolated Canada daily 300 arc second climate grids\n",
-       "     target_id: ANUSPLIN300\n",
-       "     target_references: McKenney, D.W., Hutchinson, M.F., Papadopol, P., Lawrence, K., Pedlar, J.,\n",
-       " Campbell, K., Milewska, E., Hopkinson, R., Price, D., and Owen, T.,\n",
-       " 2011. Customized spatial climate models for North America.\n",
-       " Bulletin of the American Meteorological Society, 92(12): 1611-1622.\n",
-       " \n",
-       " Hopkinson, R.F., McKenney, D.W., Milewska, E.J., Hutchinson, M.F.,\n",
-       " Papadopol, P., Vincent, L.A., 2011. Impact of aligning climatological day\n",
-       " on gridding daily maximum-minimum temperature and precipitation over Canada.\n",
-       " Journal of Applied Meteorology and Climatology 50: 1654-1665.\n",
-       "     target_version: canada_daily_standard_grids\n",
-       "     target_history: obtained: 2 April 2012, 14 June 2012, and 30 January 2013\n",
-       "     target_contact: Pia Papadopol (pia.papadopol@nrcan-rncan.gc.ca)\n",
-       "     title: Bias Correction/Constructed Analogue Quantile Mapping (BCCAQ) downscaling model output for Canada\n",
-       "     creation_date: 2013-10-16T15:54:57Z\n",
-       "     history: Tue Jun 23 10:41:16 2020: ncatted -a _FillValue,gdd,m,f,-32768. gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc\n",
-       "     NCO: 4.7.2\n",
-       "     project_id: CMIP5\n",
-       "     initialization_method: 1\n",
-       "     physics_version: 1\n",
-       "     model_id: CanESM2\n",
-       "     experiment_id: rcp85\n",
-       "     institute_ID: PCIC\n",
-       "     address: University House 1\n",
-       "     Institution: Pacific Climate Impacts Consortium (PCIC), Victoria, BC, www.pacificclimate.org\n",
-       "     dimensions(sizes): lon(313), lat(145), time(150)\n",
-       "     variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 gdd(time, lat, lon)\n",
-       "     groups: ]"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "nc_to_dataset(local_output.get()[0])\n",
-    "auto_construct_outputs(local_output.get())"
+    "local_output = thunderbird.update_metadata(updates_file = updates_file, netcdf = local_netcdf)\n",
+    "local_output_data = local_output.get(asobj=True)[0]"
    ]
   },
   {
@@ -237,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,14 +181,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def test_metadata(output):\n",
-    "    output_data = nc_to_dataset(output.get()[0])\n",
-    "    \n",
-    "   # updated metadata\n",
+    "def test_metadata(output_data):\n",
+    "    # updated metadata\n",
     "    metadata = {\n",
     "        \"institute_ID\": output_data.institute_ID,\n",
     "        \"address\": output_data.address,\n",
@@ -277,12 +198,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_metadata(opendap_output)\n",
-    "test_metadata(local_output)"
+    "test_metadata(opendap_output_data)\n",
+    "test_metadata(local_output_data)"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,10 @@ ce-dataprep==0.8.6
 cftime==1.1.3
 click==7.1.2
 jinja2==2.11.2
-netCDF4==1.5.4
+netCDF4==1.5.6
 psutil==5.7.0
 pywps==4.2.9
 xarray==0.15.1
 nchelpers==5.5.7
 wps-tools==1.2.0
+cdo==1.5.3


### PR DESCRIPTION
Resolves #148 
`asobj=True` works for netcdf files and text files, but not metalink. Metalink content is still processed with `wps_tools.output_handling`

Test on port `30874`