### PR TITLE
I163 resolve dependencies

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-ce-dataprep==0.8.6
+ce-dataprep==0.8.8
 cftime==1.1.3
 click==7.1.2
-jinja2>=2.11.3
+jinja2>=2.11.3,<3.1.0
 netCDF4==1.5.6
 psutil==5.7.0
 pywps==4.2.9

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ bumpversion
 twine
 # Changing dependencies above this comment will create merge conflicts when updating the cookiecutter template with cruft. Add extra requirements below this line.
 cruft
+nbclient~=0.5.10
 black==19.10b0
 jupyterlab==2.1.5
 ipywidgets==7.5.1

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.md")).read()
 CHANGES = open(os.path.join(here, "CHANGES.md")).read()
+REQUIRES_PYTHON = ">=3.7.0"
 
 about = {}
 with open(os.path.join(here, "thunderbird", "__version__.py"), "r") as f:
@@ -27,9 +28,8 @@ classifiers = [
     "Programming Language :: Python",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
@@ -42,6 +42,7 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
     url="https://github.com/pacificclimate/thunderbird",
+    python_requires=REQUIRES_PYTHON,
     classifiers=classifiers,
     license="GNU General Public License v3",
     keywords="wps pywps birdhouse thunderbird",


### PR DESCRIPTION
This PR resolves #163. In doing so, `nbclient` has been pinned to `~0.5.10` to resolve the incompatibility with `pytest-notebook`, `jinja2` has an upper bound of `<3.1.0` to fix the `ImportError` when running automated tests, and support for Python 3.6 has dropped. Additionally, `ce-dataprep` has been updated to the latest version.